### PR TITLE
Fix broken /faq redirect

### DIFF
--- a/src/routers/faq.js
+++ b/src/routers/faq.js
@@ -2,7 +2,7 @@ const { Router } = require('express');
 const router = new Router();
 
 router.get('/', (request, response) => {
-	res.redirect('/#faq');
+	response.redirect('/#faq');
 });
 
 module.exports = router;


### PR DESCRIPTION
The FAQ redirect from https://pretendo.network/faq is broken, and shows
![image](https://user-images.githubusercontent.com/49426949/119665744-fa30a180-be34-11eb-9aa1-009825a87a2f.png)
This fixes it.