### PR TITLE
Fix broken OpenGraph description tag and update copyright year

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -15,7 +15,7 @@
 		<meta name="theme-color" content="#673db6">
 		<!-- open graph/embeds -->
 		<meta property="og:title" content="Pretendo Network">
-		<meta property="og:escription" content="Pretendo is a as close as possible recreation of the original Nintendo Network for 3ds and Wiiu. It is an replacement for if the original servers shut down.">
+		<meta property="og:description" content="Pretendo is an open source Nintendo Network replacement that aims to build custom servers for the WiiU and 3DS family of consoles. Our goal is to preserve the online functionality of these consoles, to allow players to continue to play their favorite WiiU and 3DS games to their fullest capacity.">
 		<meta property="og:type" content="website">
 		<meta property="og:url" content="http://pretendo.network/">
 		<meta property="og:image" content="http://pretendo.network/assets/og_image.png">

--- a/views/partials/footer.handlebars
+++ b/views/partials/footer.handlebars
@@ -1,1 +1,1 @@
-<footer>Copyright 2020 - Design by mrjvs, development by Jip Fr</footer>
+<footer>Copyright 2021 - Design by mrjvs, development by Jip Fr</footer>


### PR DESCRIPTION
Came across this while changing some stuff in the localization tester, so I thought I'd fix it.