### PR TITLE
Replace trello-new with trello (reverts f8c7eca)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ioredis": "^4.26.0",
         "morgan": "^1.10.0",
         "redis-json": "^5.0.0",
-        "trello-new": "^1.0.0"
+        "trello": "^0.10.0"
       }
     },
     "node_modules/accepts": {
@@ -621,35 +621,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node_modules/needle": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
-      "integrity": "sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/needle/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -831,6 +802,33 @@
         "node": ">=4"
       }
     },
+    "node_modules/restler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/restler/-/restler-3.3.0.tgz",
+      "integrity": "sha1-+TpZteG8LFrQwrlz94EpshgbYHY=",
+      "dependencies": {
+        "iconv-lite": "0.2.11",
+        "qs": "1.2.0",
+        "xml2js": "0.4.0",
+        "yaml": "0.2.3"
+      },
+      "engines": {
+        "node": ">= 0.10.x"
+      }
+    },
+    "node_modules/restler/node_modules/iconv-lite": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+      "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/restler/node_modules/qs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
+      "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -840,11 +838,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/send": {
       "version": "0.17.1",
@@ -922,14 +915,14 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/trello-new": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trello-new/-/trello-new-1.0.0.tgz",
-      "integrity": "sha512-6nX6eHElNLufQ0xF6bwyiMnSfszhRunA+N2qC7Za5VpM6hOmzkckp0muIo3XCuCaIyMfkZCAV37xYry1nD98yw==",
+    "node_modules/trello": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/trello/-/trello-0.10.0.tgz",
+      "integrity": "sha512-l2uDieuUkFU+qlZG1dtu11Uzg5yKZLl+NjVCAQWumaHnclH46cTuBEyHjnz7kPqZDNoGf7qzcsln0BOVjrFajw==",
       "dependencies": {
         "es6-promise": "~3.0.2",
-        "needle": "^2.4.0",
-        "object-assign": "~4.1.0"
+        "object-assign": "~4.1.0",
+        "restler": "~3.3.0"
       },
       "engines": {
         "node": ">= 0.10.x"
@@ -1003,6 +996,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.0.tgz",
+      "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
+      "dependencies": {
+        "sax": "0.5.x",
+        "xmlbuilder": ">=0.4.2"
+      }
+    },
+    "node_modules/xml2js/node_modules/sax": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
+      "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc=",
+      "engines": {
+        "node": "*"
+      }
     }
   },
   "dependencies": {
@@ -1477,31 +1500,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "needle": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
-      "integrity": "sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==",
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -1635,6 +1633,29 @@
         "redis-errors": "^1.0.0"
       }
     },
+    "restler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/restler/-/restler-3.3.0.tgz",
+      "integrity": "sha1-+TpZteG8LFrQwrlz94EpshgbYHY=",
+      "requires": {
+        "iconv-lite": "0.2.11",
+        "qs": "1.2.0",
+        "xml2js": "0.4.0",
+        "yaml": "0.2.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.2.11",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+        },
+        "qs": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
+          "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1644,11 +1665,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "send": {
       "version": "0.17.1",
@@ -1713,14 +1729,14 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
-    "trello-new": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trello-new/-/trello-new-1.0.0.tgz",
-      "integrity": "sha512-6nX6eHElNLufQ0xF6bwyiMnSfszhRunA+N2qC7Za5VpM6hOmzkckp0muIo3XCuCaIyMfkZCAV37xYry1nD98yw==",
+    "trello": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/trello/-/trello-0.10.0.tgz",
+      "integrity": "sha512-l2uDieuUkFU+qlZG1dtu11Uzg5yKZLl+NjVCAQWumaHnclH46cTuBEyHjnz7kPqZDNoGf7qzcsln0BOVjrFajw==",
       "requires": {
         "es6-promise": "~3.0.2",
-        "needle": "^2.4.0",
-        "object-assign": "~4.1.0"
+        "object-assign": "~4.1.0",
+        "restler": "~3.3.0"
       }
     },
     "type-is": {
@@ -1770,6 +1786,32 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.0.tgz",
+      "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
+      "requires": {
+        "sax": "0.5.x",
+        "xmlbuilder": ">=0.4.2"
+      },
+      "dependencies": {
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
+    },
+    "yaml": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-0.2.3.tgz",
+      "integrity": "sha1-tUUOkudu82td0k42YAkeuu7z5cc="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "ioredis": "^4.26.0",
     "morgan": "^1.10.0",
     "redis-json": "^5.0.0",
-    "trello-new": "^1.0.0"
+    "trello": "^0.10.0"
   }
 }

--- a/src/trello.js
+++ b/src/trello.js
@@ -1,4 +1,4 @@
-const Trello =require("trello-new")
+const Trello =require("trello")
 const Redis = require('ioredis');
 const JSONCache = require('redis-json');
 const config = require('../config.json');


### PR DESCRIPTION
`trello-new` currently has [a bug](https://github.com/mmoomocow/trello/issues/14) that prevents the page from loading. This pull reverts to the regular `trello` package, from before f8c7eca