### PR TITLE
Update BR_pt.json

### DIFF
--- a/locales/BR_pt.json
+++ b/locales/BR_pt.json
@@ -7,61 +7,61 @@
 	},
 	"hero": {
 		"subtitle": "Servidores de jogos",
-		"title": "Recreated",
-		"text": "Pretendo é uma reposição gratuíta e de código aberto para os servidores de ambos 3DS e Wii U, permitindo conectividade online para todos, mesmo após os servidores originais serem descontinuados",
+		"title": "Recriados",
+		"text": "Pretendo é uma reposição gratuíta e de código aberto para os servidores do Wii U e Nintendo 3DS, permitindo conectividade online para todos, mesmo após o encerramento dos servidores originais",
 		"buttons": {
-			"readMore": "Mostrar mais"
+			"readMore": "Saiba mais"
 		}
 	},
 	"aboutUs": {
 		"title": "Sobre nós",
 		"paragraphs": [
-			"Pretendo é um projeto de código aberto que visa recriar a Nintendo Network para o 3DS e Wii U usando design de sala limpa.",
+			"Utilizando do design de sala limpa, Pretendo é um projeto de código aberto que visa recriar a Nintendo Network para o Wii U e para família de consoles Nintendo 3DS.",
 			"Como os nossos serviços serão gratuitos e de código aberto, eles podem continuar existindo por muito mais tempo após o inevitável encerramento da Nintendo Network."
 		]
 	},
 	"progress": {
 		"title": "Progresso",
 		"paragraphs": [
-			"Atualmente estamos trabalhando no Miiverse, juntamente com nossos servidores de contas e sua integração com os serviços.",
-			"Para o 3DS também estamos trabalhando no Mario Kart 7, com o desejo de trabalhar em outros jogos quando possível."
+			"Atualmente estamos trabalhando no Miiverse, assinm como no nossos servidores de contas e suas integrações com os serviços.",
+			"Para o Nintendo 3DS também estamos trabalhando no Mario Kart 7, pretendemos trabalhar em outros jogos quando possível."
 		]
 	},
 	"faq": {
-		"title": "Perguntas frequentes (FAQ)",
-		"text": "Para a fácil obtenção de informações, aqui estão algumas perguntas comuns que nos são feitas.",
+		"title": "Perguntas frequentes",
+		"text": "Para a fácil obtenção de informações, aqui estão algumas das perguntas mais comuns.",
 		"QAs": [
 			{
 				"question": "O que é Pretendo?",
-				"answer": "Pretendo é uma reposição de código aberto da Nintendo Network que visa fornecer servidores personalizados para a família de consoles Wii U e 3DS. Nosso objetivo é preservar a funcionalidade online desses consoles, para permitir que os jogadores continuem a experienciar seus jogos favoritos do Wii U e 3DS em sua capacidade máxima."
+				"answer": "Pretendo é uma reposição de código aberto para a Nintendo Network que visa fornecer servidores personalizados para o Wii U e a família de consoles Nintendo 3DS. Nosso objetivo é preservar as funcionalidades online desses consoles para permitir que os jogadores continuem experienciando seus jogos favoritos em sua capacidade máxima."
 			},
 			{
-				"question": "Meus NNIDs existentes funcionarão no Pretendo?",
-				"answer": "Infelizmente não. Os NNIDs existentes não funcionarão no Pretendo, pois apenas a Nintendo mantém acesso aos seus dados de usuário; embora uma migração de NNID para PNID seja teoricamente possível, seria arriscado e exigiria dados confidenciais do usuário que não desejamos manter."
+				"question": "Meus NNIDs existentes funcionarão na Pretendo?",
+				"answer": "Infelizmente não. Os NNIDs existentes não funcionarão na Pretendo, apenas a Nintendo tem acesso aos seus dados de usuário; embora uma migração de NNID para PNID seja teoricamente possível, seria arriscado e exigiria dados confidenciais do usuário que não desejamos manter."
 			},
 			{
-				"question": "Como eu uso o Pretendo?",
-				"answer": "Pretendo atualmente não está disponível em um estado para uso público. No entanto, quando estiver pronto, você poderá usar o Pretendo simplesmente executando nosso patcher homebrew no seu console."
+				"question": "Como eu uso a Pretendo?",
+				"answer": "Pretendo atualmente não está disponível em um estado para uso do público geral. No entanto, quando estiver pronto, você poderá usar a Pretendo executando nosso patcher homebrew no seu console."
 			},
 			{
-				"question": "Você sabe quando <feature/service> estará pronto?",
-				"answer": "Não. Muitos dos recursos e serviços do Pretendo são desenvolvidos de forma independente (por exemplo, o Miiverse pode ser trabalhado por um desenvolvedor enquanto contas e amigos são trabalhados por outro) e, portanto, não podemos fornecer uma data estimada de quanto tempo isso levará."
+				"question": "Você sabe quando recurso / serviço estará pronto?",
+				"answer": "Não. Muitos dos recursos e serviços da Pretendo são desenvolvidos de forma independente (por exemplo, o Miiverse pode ser trabalhado por um desenvolvedor enquanto contas e lista de amigos são trabalhados por outro) e, portanto, não podemos fornecer uma data estimada de quanto tempo isso levará."
 			},
 			{
-				"question": "O Pretendo funciona com Cemu/emuladores?",
-				"answer": "Pretendo é primariamente projetado para o Wii U e 3DS; no momento, o único emulador para esses consoles com suporte para Nintendo Network é o Cemu. O Cemu não fornece oficialmente suporte a servidores personalizados, mas ainda deve ser possível usar o Pretendo com o Cemu.<br>O Pretendo atualmente não oferece suporte ao Cemu."
+				"question": "A Pretendo funciona em emualdores?",
+				"answer": "Pretendo é primariamente projetado para o Wii U e Nintendo 3DS; no momento, o único emulador para um desses consoles com suporte a Nintendo Network é o Cemu. O Cemu oficialmente não fornece suporte a servidores personalizados, mas ainda deve ser possível usar a Pretendo com o Cemu.<br>A Pretendo não oferece suporte ao Cemu no momento."
 			},
 			{
-				"question": "Se eu for banido da Nintendo Network, continuarei banido ao usar o Pretendo?",
-				"answer": "Não temos acesso aos banimentos da Nintendo Network e nem todos os usuários serão banidos do nosso serviço. No entanto, teremos regras a seguir ao usar o serviço e o não cumprimento dessas regras pode resultar em banimento."
+				"question": "Se eu for banido da Nintendo Network, continuarei banido ao usar a Pretendo?",
+				"answer": "Não temos acesso aos banimentos da Nintendo Network e nem todos os usuários serão banidos do nosso serviço. No entanto, teremos regras quem devem ser seguidas ao utilizar o serviço e o não cumprimento dessas regras pode resultar em um banimento."
 			},
 			{
-				"question": "Will Pretendo support the Wii/Switch?",
-				"answer": "The Wii already has custom servers provided by <a href=\"https://wiimmfi.de/\" target=\"_blank\">Wiimmfi</a>. We currently do not wish to target the Switch as it is both paid and completely different to Nintendo Network."
+				"question": "Pretendo terá suporte ao Wii / Nintendo Switch?",
+				"answer": "O Wii já possui servidores personalizados fornecidos pelo <a href=\"https://wiimmfi.de/\" target=\"_blank\">Wiimmfi</a>. No momento, não temos interesse em direcionar o projeto ao Nintendo Switch, pois ele oferece um serviço pago e completamente diferente da Nintendo Network."
 			},
 			{
-				"question": "Vou precisar de um desbloqueio para me conectar?",
-				"answer": "Sim, você precisará desbloquear seu console para se conectar; no entanto, no Wii U você só precisará acessar o Homebrew Launcher (ou seja, Haxchi, Coldboot Haxchi ou mesmo o exploit no navegador de internet), informações sobre como o 3DS se conectará serão fornecidas em uma data posterior."
+				"question": "Terei de desbloquear meu console para me conectar?",
+				"answer": "Sim, você precisará desbloquear seu console para se conectar; no entanto, no Wii U você só precisará acessar o Homebrew Launcher (ou seja, Haxchi, Coldboot Haxchi ou até mesmo o exploit do navegador de internet), informações sobre como consoles Nintendo 3DS se conectarão serão fornecidas em uma data posterior."
 			}
 		]
 	},
@@ -119,7 +119,7 @@
 			},
 			{
 				"name": "Shutterbug2000",
-				"caption": "Pesquisa do 3DS e Mario Kart 7",
+				"caption": "Pesquisa do Nintendo 3DS e Mario Kart 7",
 				"picture": "https://cdn.discordapp.com/avatars/191370953807233024/0311b61e2009c1576828dd2e9a59d72e.png?size=128",
 				"github": "https://github.com/shutterbug2000"
 			},

--- a/locales/BR_pt.json
+++ b/locales/BR_pt.json
@@ -41,11 +41,11 @@
 			},
 			{
 				"question": "Como eu uso a Pretendo?",
-				"answer": "Pretendo atualmente não está disponível em um estado para uso do público geral. No entanto, quando estiver pronto, você poderá usar a Pretendo executando nosso patcher homebrew no seu console."
+				"answer": "Pretendo atualmente não está disponível em um estado para uso pelo público geral. No entanto, quando estiver pronto, você poderá usar a Pretendo executando nosso patcher homebrew no seu console."
 			},
 			{
 				"question": "Você sabe quando recurso / serviço estará pronto?",
-				"answer": "Não. Muitos dos recursos e serviços da Pretendo são desenvolvidos de forma independente (por exemplo, o Miiverse pode ser trabalhado por um desenvolvedor enquanto contas e lista de amigos são trabalhados por outro) e, portanto, não podemos fornecer uma data estimada de quanto tempo isso levará."
+				"answer": "Não. Muitos dos recursos e serviços da Pretendo são desenvolvidos de forma independente (por exemplo, o Miiverse pode ser trabalhado por um desenvolvedor enquanto as contas e lista de amigos são trabalhados por outro) e, portanto, não podemos fornecer uma data estimada de quanto tempo isso levará."
 			},
 			{
 				"question": "A Pretendo funciona em emualdores?",


### PR DESCRIPTION
- Translated new and missing fields.
- Removed a few text redundancies.
- Changed "3DS" and "Switch" to "Nintendo 3DS" and "Nintendo Switch" respectively.
- Changed all mentions to "Pretendo" and "Pretendo Network" from masculine noun (o, do, no) to female noun (a, da, na).