### PR TITLE
BR_pt - fix misspelled words and special thanks translation

### DIFF
--- a/locales/BR_pt.json
+++ b/locales/BR_pt.json
@@ -24,7 +24,7 @@
 	"progress": {
 		"title": "Progresso",
 		"paragraphs": [
-			"Atualmente estamos trabalhando no Miiverse, assinm como no nossos servidores de contas e suas integrações com os serviços.",
+			"Atualmente estamos trabalhando no Miiverse, assim como no nossos servidores de contas e suas integrações com os serviços.",
 			"Para o Nintendo 3DS também estamos trabalhando no Mario Kart 7, pretendemos trabalhar em outros jogos quando possível."
 		]
 	},
@@ -121,8 +121,8 @@
 		]
 	},
 	"specialThanks": {
-		"title": "Special thanks",
-		"text": "Without them, Pretendo wouldn't be where it is today.",
+		"title": "Agradecimentos especiais",
+		"text": "Sem eles, Pretendo não estaria onde está hoje.",
 		"people": [
 			{
 				"name": "superwhiskers",


### PR DESCRIPTION
* Fix a misspelled word
* Based on other locales, the Special Thanks title and text were translated
    * At least for me, it does not make sense of being the only which was not translated