### PR TITLE
Mention RiiConnect24 in the Wii FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# Website for Pretendo Network
+# Website
 
-This is the Repository for the Website of the Pretendo Network.
+This repository contains the source code for [our website](https://pretendo.network). All contributions should go in the [dev branch](https://github.com/PretendoNetwork/website/tree/dev).
 
-Contributions should go in the [dev branch](https://github.com/PretendoNetwork/website/tree/dev).
+### Localization
+If you'd like to help localize Pretendo Network, you can check out our project on [Weblate](https://hosted.weblate.org/engage/pretendonetwork/).
 
-Visit the [live version](https://pretendo.network)
+<a href="https://hosted.weblate.org/engage/pretendonetwork/">
+    <img src="https://hosted.weblate.org/widgets/pretendonetwork/-/website/multi-auto.svg" alt="Translation status" />
+</a>
+
+* * *
+
+Join our Discord:
 
 <a href="https://discord.gg/DThgbba" target="_blank">
     <img src="https://discordapp.com/api/guilds/408718485913468928/widget.png?style=banner3">

--- a/locales/US_en.json
+++ b/locales/US_en.json
@@ -60,7 +60,7 @@
 			},
 			{
 				"question": "Will Pretendo support the Wii/Switch?",
-				"answer": "The Wii already has custom servers provided by <a href=\"https://wiimmfi.de/\" target=\"_blank\">Wiimmfi</a>. We currently do not wish to target the Switch as it is both paid and completely different to Nintendo Network."
+				"answer": "The Wii already has custom servers provided by <a href=\"https://wiimmfi.de/\" target=\"_blank\">Wiimmfi</a> and <a href=\"https://rc24.xyz/\" targer=\"_blank\">RiiConnect24</a>. We currently do not wish to target the Switch as it is both paid and completely different to Nintendo Network."
 			},
 			{
 				"question": "Will I need hacks to connect?",

--- a/locales/US_en.json
+++ b/locales/US_en.json
@@ -60,7 +60,7 @@
 			},
 			{
 				"question": "Will Pretendo support the Wii/Switch?",
-				"answer": "The Wii already has custom servers provided by <a href=\"https://wiimmfi.de/\" target=\"_blank\">Wiimmfi</a> and <a href=\"https://rc24.xyz/\" targer=\"_blank\">RiiConnect24</a>. We currently do not wish to target the Switch as it is both paid and completely different to Nintendo Network."
+				"answer": "The Wii already has custom servers provided by <a href=\"https://wiimmfi.de/\" target=\"_blank\">Wiimmfi</a> and <a href=\"https://rc24.xyz/\" target=\"_blank\">RiiConnect24</a>. We currently do not wish to target the Switch as it is both paid and completely different to Nintendo Network."
 			},
 			{
 				"question": "Will I need hacks to connect?",


### PR DESCRIPTION
Some of the Wii's custom servers are hosted by @RiiConnect24 not Wiimmfi (they do different things, but are both worth mentioning here), so this adds a link to rc24.xyz, RiiConnect24's website.