### PR TITLE
Fix localization handlebars error

### DIFF
--- a/views/localization.handlebars
+++ b/views/localization.handlebars
@@ -6,17 +6,17 @@
 
 	<div class="localization-wrapper">
 		<div class="localization-widget">
-			<h1 class="title dot">{{ locale.localizationPage.title" }}</h1>
-			<p class="caption">{{ locale.localizationPage.description" }}</p>
+			<h1 class="title dot">{{ locale.localizationPage.title }}</h1>
+			<p class="caption">{{ locale.localizationPage.description }}</p>
 			<a href="https://github.com/PretendoNetwork/Pretendo/blob/master/CONTRIBUTING.md#localization" target="_blank"  class="localization-instr">
 				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--accent-shade-2)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="feather feather-arrow-right"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
-				{{ locale.localizationPage.instructions" }}
+				{{ locale.localizationPage.instructions }}
 			</a>
 			<form class="localization-form" autocomplete="off">
-				<label for="url">{{ locale.localizationPage.fileInput" }}</label>
+				<label for="url">{{ locale.localizationPage.fileInput }}</label>
 				<div class="input-wrapper">
-					<input type="url" id="url" placeholder="{{ locale.localizationPage.filePlaceholder" }}" required />
-					<button type="submit" class="submit-btn">{{ locale.localizationPage.button" }}</button>
+					<input type="url" id="url" placeholder="{{ locale.localizationPage.filePlaceholder }}" required />
+					<button type="submit" class="submit-btn">{{ locale.localizationPage.button }}</button>
 				</div>
 			</form>
 		</div>


### PR DESCRIPTION
When I go to the [pretendo.network/localization](https://pretendo.network/localization), I get the following error:

```
Error: Parse error on line 9:
...le.localizationPage.title" }}</h1>			<p
-----------------------^
Expecting 'ID', got 'INVALID'
    at Parser.parseError (/home/*****/website/node_modules/handlebars/dist/cjs/handlebars/compiler/parser.js:267:19)
    at Parser.parse (/home/*****/website/node_modules/handlebars/dist/cjs/handlebars/compiler/parser.js:336:30)
    at parseWithoutProcessing (/home/*****/website/node_modules/handlebars/dist/cjs/handlebars/compiler/base.js:46:33)
    at HandlebarsEnvironment.parse (/home/*****/website/node_modules/handlebars/dist/cjs/handlebars/compiler/base.js:52:13)
    at compileInput (/home/*****/website/node_modules/handlebars/dist/cjs/handlebars/compiler/compiler.js:508:19)
    at ret (/home/*****/website/node_modules/handlebars/dist/cjs/handlebars/compiler/compiler.js:517:18)
    at ExpressHandlebars._renderTemplate (/home/*****/website/node_modules/express-handlebars/lib/express-handlebars.js:261:10)
    at ExpressHandlebars.render (/home/*****/website/node_modules/express-handlebars/lib/express-handlebars.js:173:21)
    at async ExpressHandlebars.renderView (/home/*****/website/node_modules/express-handlebars/lib/express-handlebars.js:232:15)
```

This pull request should fix this error :)