### PR TITLE
Fix corrupted link in dutch translation

### DIFF
--- a/locales/nl_NL.json
+++ b/locales/nl_NL.json
@@ -212,7 +212,7 @@
 	},
 	"donation": {
 		"progress": "<span>$${totd}</span> van <span>$${goald}</span>/maand, <span>${perc}%</span> van de maandelijkse doelstelling.",
-		"upgradePush": "Om een abonnee te worden en toegang te krijgen tot coole voordelen, bezoek je de a href=\"/account/upgrade\"&gt;upgrade pagina."
+		"upgradePush": "Om een abonnee te worden en toegang te krijgen tot coole voordelen, bezoek je de <a href=\"/account/upgrade\">upgrade pagina</a>."
 	},
 	"upgrade": {
 		"changeTierPrompt": "Weet je zeker dat je je abonnement op <span class=\"oldtier\">oldtiername</span> wilt opzeggen en je wilt aanmelden voor <span class=\"newtier\">newtiername</span>?",


### PR DESCRIPTION
I found this corrupted html element while scrolling through [the progress page](https://pretendo.network/progress).
![image](https://user-images.githubusercontent.com/59965542/229062823-6f127c9a-0625-4f43-9c6a-da5a342d4ea7.png)