### PR TITLE
Allow Bandwidth's messages to be dismissed

### DIFF
--- a/views/partials/footer.handlebars
+++ b/views/partials/footer.handlebars
@@ -85,9 +85,14 @@
 			`${unescapeHTML("{{this}}")}`,
 		{{/each}}
 		]
-
-		bandwidthRaccoon.addEventListener("click", () =>
+		
+		document.body.addEventListener("click", () =>
 		{
+			bandwidthRaccoonWrapper.classList.remove("speak");
+		})
+		bandwidthRaccoon.addEventListener("click", (event) =>
+		{
+			event.stopPropagation();
 			bandwidthRaccoonWrapper.classList.add("speak");
 			if (!randomSentences[i]) {
 				i = 0


### PR DESCRIPTION
On devices with a small viewport, such as a smartphone, after Bandwidth has been clicked, you are unable to access the links in the footer without reloading the page.
![pretendo network_](https://github.com/PretendoNetwork/website/assets/43019219/5cbb0d28-06b0-40e9-b690-b29773b23db5)
This PR makes it so that when you click elsewhere on the page, it will dismiss Bandwidth's prompt.