### PR TITLE
Update SpotPass dumping docs to mention BOSS task databases

### DIFF
--- a/docs/en_US/network-dumps.md
+++ b/docs/en_US/network-dumps.md
@@ -109,7 +109,7 @@ Once you have the proxy server running and your console connected to it, use the
 For advanced usage of the proxy server, see https://github.com/PretendoNetwork/mitmproxy-nintendo
 
 # SpotPass
-SpotPass data, also called BOSS content, is sent using HTTP. The easiest way to submit SpotPass information to us is by dumping your consoles BOSS database. This will give us the data needed to archive SpotPass content ourselves. Alternatively, you may submit [HTTP network dumps](#http-packets). Submitting HTTP network dumps gives us the SpotPass content as well, but requires more work on users.
+SpotPass data, also called BOSS content, is sent using HTTP. The easiest way to submit SpotPass information to us is by dumping your consoles BOSS database. These databases contain SpotPass information for all games which you have enabled SpotPass for. This will give us the data needed to archive SpotPass content ourselves. Alternatively, you may submit [HTTP network dumps](#http-packets). Submitting HTTP network dumps gives us the SpotPass content as well, but requires more work on users.
 
 For a list of games which use SpotPass content and still need to be archived, see [this spreadsheet](https://docs.google.com/spreadsheets/d/1qU0o7zxILAZcI83nOidr1QSrM0maVp6OGdBqg0xwul0/edit?usp=sharing).
 
@@ -121,7 +121,9 @@ SpotPass content is region specific, so dumps of one games region may not work f
 
 If you are uploading HTTP network dumps, please include the name of the game and it's region in your description.
 
-If you are uploading your BOSS database, the way you dump the BOSS database depends on your console:
+If you are uploading your BOSS database, ensure your game has registered your BOSS tasks. Typically a game will register all of it's tasks once SpotPass is enabled for the game. A game may require you to be online before asking to enable SpotPass, but this depends on the game.
+
+We encourage everyone to upload their task databases, even if you have not been online in a long time. These databases may contain SpotPass information from games you have played in the past.
 
 ## Wii U
 The Wii U stores a separate database of BOSS tasks per user. Each one must be dumped and submitted individually.

--- a/docs/en_US/network-dumps.md
+++ b/docs/en_US/network-dumps.md
@@ -128,24 +128,24 @@ We encourage everyone to upload their task databases, even if you have not been 
 ## Wii U
 The Wii U stores a separate database of BOSS tasks per user. Each one must be dumped and submitted individually.
 
-- Connect to the Wii U using [FTP](https://wiki.hacks.guide/wiki/Wii_U:FTP#Aroma-0)
-- Navigate to `/storage_mlc/usr/save/system/boss`
-- Copy all the folders in this directory to your PC
-- Submit the `task.db` file in each folder using Bandwidth
+1. Connect to the Wii U using [FTP](https://wiki.hacks.guide/wiki/Wii_U:FTP#Aroma-0)
+2. Navigate to `/storage_mlc/usr/save/system/boss`
+3. Copy all the folders in this directory to your PC
+4. Submit the `task.db` file in each folder using Bandwidth
 
 ## 3DS
 The 3DS stores BOSS tasks in a single save file in the BOSS sysmodule.
 
-- Launch [GodMode9](https://github.com/d0k3/GodMode9)
-- Navigate to `SYSNAND CTRNAND > data > longstring > sysdata > 00010034`
-- Select `00000000`. If your file is not named `00000000` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
-- Select `Mount as DISA image`
-- Press `A` to mount and enter the image
-- Select `partitionA.bin`. If your file is not named `partitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
-- Select `Copy to 0:/gm9/out`
-- Turn off your console and eject the SD card
-- Open your SD card on your computer
-- Submit the partition BIN file using Bandwidth
+1. Launch [GodMode9](https://github.com/d0k3/GodMode9)
+2. Navigate to `SYSNAND CTRNAND > data > longstring > sysdata > 00010034`
+3. Select `00000000`. If your file is not named `00000000` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
+4. Select `Mount as DISA image`
+5. Press `A` to mount and enter the image
+6. Select `partitionA.bin`. If your file is not named `partitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
+7. Select `Copy to 0:/gm9/out`
+8. Turn off your console and eject the SD card
+9. Open your SD card on your computer
+10. Submit the partition BIN file using Bandwidth
 
 # High Priority Games
 While all games are important to capture dumps for, this is a list of games we have identified as being high priority. All games on Nintendo Network share a common set of protocols used to implement the games online features, making it easy to use work from one game on many others. However these games have game-specific patches to their protocols, or even entirely custom ones, making this much harder to work with, especially after the official servers go down. Dumps for these games are considered high priority, but they should not be the only games dumped for. All games are important.

--- a/docs/en_US/network-dumps.md
+++ b/docs/en_US/network-dumps.md
@@ -134,7 +134,7 @@ The Wii U stores a separate database of BOSS tasks per user. Each one must be du
 4. Submit the `task.db` file in each folder using Bandwidth.
 
 ## 3DS
-The 3DS stores BOSS tasks in a single save file in the BOSS sysmodule.
+The 3DS stores BOSS tasks in a single partition in the BOSS sysmodule.
 
 1. Launch [GodMode9](https://github.com/d0k3/GodMode9).
 2. Navigate to `SYSNAND CTRNAND > data > longstring > sysdata > 00010034`.

--- a/docs/en_US/network-dumps.md
+++ b/docs/en_US/network-dumps.md
@@ -128,24 +128,24 @@ We encourage everyone to upload their task databases, even if you have not been 
 ## Wii U
 The Wii U stores a separate database of BOSS tasks per user. Each one must be dumped and submitted individually.
 
-1. Connect to the Wii U using [FTP](https://wiki.hacks.guide/wiki/Wii_U:FTP#Aroma-0)
-2. Navigate to `/storage_mlc/usr/save/system/boss`
-3. Copy all the folders in this directory to your PC
-4. Submit the `task.db` file in each folder using Bandwidth
+1. Connect to the Wii U using [FTP](https://wiki.hacks.guide/wiki/Wii_U:FTP#Aroma-0).
+2. Navigate to `/storage_mlc/usr/save/system/boss`.
+3. Copy all the folders in this directory to your PC.
+4. Submit the `task.db` file in each folder using Bandwidth.
 
 ## 3DS
 The 3DS stores BOSS tasks in a single save file in the BOSS sysmodule.
 
-1. Launch [GodMode9](https://github.com/d0k3/GodMode9)
-2. Navigate to `SYSNAND CTRNAND > data > longstring > sysdata > 00010034`
-3. Select `00000000`. If your file is not named `00000000` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
-4. Select `Mount as DISA image`
-5. Press `A` to mount and enter the image
-6. Select `partitionA.bin`. If your file is not named `partitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
-7. Select `Copy to 0:/gm9/out`
-8. Turn off your console and eject the SD card
-9. Open your SD card on your computer
-10. Submit the partition BIN file using Bandwidth
+1. Launch [GodMode9](https://github.com/d0k3/GodMode9).
+2. Navigate to `SYSNAND CTRNAND > data > longstring > sysdata > 00010034`.
+3. Select `00000000`. If your file is not named `00000000` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each.
+4. Select `Mount as DISA image`.
+5. Press `A` to mount and enter the image.
+6. Select `partitionA.bin`. If your file is not named `partitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each.
+7. Select `Copy to 0:/gm9/out`.
+8. Turn off your console and eject the SD card.
+9. Open your SD card on your computer.
+10. Submit the partition BIN file using Bandwidth.
 
 # High Priority Games
 While all games are important to capture dumps for, this is a list of games we have identified as being high priority. All games on Nintendo Network share a common set of protocols used to implement the games online features, making it easy to use work from one game on many others. However these games have game-specific patches to their protocols, or even entirely custom ones, making this much harder to work with, especially after the official servers go down. Dumps for these games are considered high priority, but they should not be the only games dumped for. All games are important.

--- a/docs/en_US/network-dumps.md
+++ b/docs/en_US/network-dumps.md
@@ -141,11 +141,11 @@ The 3DS stores BOSS tasks in a single save file in the BOSS sysmodule.
 - Select `00000000`. If your file is not named `00000000` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
 - Select `Mount as DISA image`
 - Press `A` to mount and enter the image
-- Select `PartitionA.bin`. If your file is not named `PartitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
+- Select `partitionA.bin`. If your file is not named `partitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
 - Select `Copy to 0:/gm9/out`
 - Turn off your console and eject the SD card
 - Open your SD card on your computer
-- submit the partition BIN file using Bandwidth
+- Submit the partition BIN file using Bandwidth
 
 # High Priority Games
 While all games are important to capture dumps for, this is a list of games we have identified as being high priority. All games on Nintendo Network share a common set of protocols used to implement the games online features, making it easy to use work from one game on many others. However these games have game-specific patches to their protocols, or even entirely custom ones, making this much harder to work with, especially after the official servers go down. Dumps for these games are considered high priority, but they should not be the only games dumped for. All games are important.

--- a/docs/en_US/network-dumps.md
+++ b/docs/en_US/network-dumps.md
@@ -109,7 +109,9 @@ Once you have the proxy server running and your console connected to it, use the
 For advanced usage of the proxy server, see https://github.com/PretendoNetwork/mitmproxy-nintendo
 
 # SpotPass
-SpotPass data, also called BOSS content, is sent using HTTP. In order to archive SpotPass content, see the above [HTTP Packets](#http-packets) section. For a list of games which use SpotPass content and still need to be archived, see [this spreadsheet](https://docs.google.com/spreadsheets/d/1qU0o7zxILAZcI83nOidr1QSrM0maVp6OGdBqg0xwul0/edit?usp=sharing).
+SpotPass data, also called BOSS content, is sent using HTTP. The easiest way to submit SpotPass information to us is by dumping your consoles BOSS database. This will give us the data needed to archive SpotPass content ourselves. Alternatively, you may submit [HTTP network dumps](#http-packets). Submitting HTTP network dumps gives us the SpotPass content as well, but requires more work on users.
+
+For a list of games which use SpotPass content and still need to be archived, see [this spreadsheet](https://docs.google.com/spreadsheets/d/1qU0o7zxILAZcI83nOidr1QSrM0maVp6OGdBqg0xwul0/edit?usp=sharing).
 
 <div class="tip">
 	<strong>This spreadsheet was generated automatically. It may be incomplete and missing games or regions. Even if your game is not on this list we encourage you to upload HTTP dumps of it.</strong>
@@ -117,7 +119,31 @@ SpotPass data, also called BOSS content, is sent using HTTP. In order to archive
 
 SpotPass content is region specific, so dumps of one games region may not work for a games other regions. All of a games regions must be checked and archived.
 
-If you are uploading SpotPass captures, please include the name of the game and it's region in your description.
+If you are uploading HTTP network dumps, please include the name of the game and it's region in your description.
+
+If you are uploading your BOSS database, the way you dump the BOSS database depends on your console:
+
+## Wii U
+The Wii U stores a separate database of BOSS tasks per user. Each one must be dumped and submitted individually.
+
+- Connect to the Wii U using [FTP](https://wiki.hacks.guide/wiki/Wii_U:FTP#Aroma-0)
+- Navigate to `/storage_mlc/usr/save/system/boss`
+- Copy all the folders in this directory to your PC
+- Submit the `task.db` file in each folder using Bandwidth
+
+## 3DS
+The 3DS stores BOSS tasks in a single save file in the BOSS sysmodule.
+
+- Launch [GodMode9](https://github.com/d0k3/GodMode9)
+- Navigate to `SYSNAND CTRNAND > data > longstring > sysdata > 00010034`
+- Select `00000000`. If your file is not named `00000000` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
+- Select `Mount as DISA image`
+- Press `A` to mount and enter the image
+- Select `PartitionA.bin`. If your file is not named `PartitionA.bin` you may still continue, though we cannot guarantee this is the correct file. If you have more than one file, repeat the following steps for each
+- Select `Copy to 0:/gm9/out`
+- Turn off your console and eject the SD card
+- Open your SD card on your computer
+- submit the partition BIN file using Bandwidth
 
 # High Priority Games
 While all games are important to capture dumps for, this is a list of games we have identified as being high priority. All games on Nintendo Network share a common set of protocols used to implement the games online features, making it easy to use work from one game on many others. However these games have game-specific patches to their protocols, or even entirely custom ones, making this much harder to work with, especially after the official servers go down. Dumps for these games are considered high priority, but they should not be the only games dumped for. All games are important.


### PR DESCRIPTION
Updates the network dumping docs SpotPass section to include information on how to submit BOSS task databases.

These databases are invaluable, as they give us information on tons of BOSS tasks without the need for network dumps. These databases contain the BOSS application IDs and associated task names, but no actual BOSS content. For actual content, an archiver or real HTTP dumps is still needed

Relies on the pending Bandwidth PR