### PR TITLE
Migrate to AWS SES

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -33,9 +33,12 @@
 			}
 		}
 	},
-	"gmail": {
-		"user": "username",
-		"pass": "password",
+	"email": {
+		"ses": {
+			"region": "AWS SES us-east-1",
+			"key": "AWS SES access key",
+			"secret": "AWS SES secret key"
+		},
 		"from": "Firstname Lastname <user@domain.com>"
 	},
 	"trello": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@aws-sdk/client-ses": "^3.515.0",
 				"@discordjs/rest": "^0.5.0",
 				"browserify": "^17.0.0",
 				"colors": "^1.4.0",
@@ -38,7 +39,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
 			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-			"optional": true,
 			"dependencies": {
 				"@aws-crypto/util": "^3.0.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -48,14 +48,12 @@
 		"node_modules/@aws-crypto/crc32/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/ie11-detection": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
 			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -63,14 +61,12 @@
 		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
 			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-			"optional": true,
 			"dependencies": {
 				"@aws-crypto/ie11-detection": "^3.0.0",
 				"@aws-crypto/sha256-js": "^3.0.0",
@@ -85,14 +81,12 @@
 		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
 			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-			"optional": true,
 			"dependencies": {
 				"@aws-crypto/util": "^3.0.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -102,14 +96,12 @@
 		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
 			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -117,14 +109,12 @@
 		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/util": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
 			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-			"optional": true,
 			"dependencies": {
 				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -134,8 +124,7 @@
 		"node_modules/@aws-crypto/util/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
 			"version": "3.441.0",
@@ -185,6 +174,496 @@
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.515.0.tgz",
+			"integrity": "sha512-X51TvcpqJ83ZOSUa/efWl+cj3cXBF6fCb2iNghjRD2McDvzGKoiR+Zaoy05doPdh/GZ7azTBqX0qKRIyUj//wg==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.515.0",
+				"@aws-sdk/core": "3.513.0",
+				"@aws-sdk/credential-provider-node": "3.515.0",
+				"@aws-sdk/middleware-host-header": "3.515.0",
+				"@aws-sdk/middleware-logger": "3.515.0",
+				"@aws-sdk/middleware-recursion-detection": "3.515.0",
+				"@aws-sdk/middleware-user-agent": "3.515.0",
+				"@aws-sdk/region-config-resolver": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@aws-sdk/util-endpoints": "3.515.0",
+				"@aws-sdk/util-user-agent-browser": "3.515.0",
+				"@aws-sdk/util-user-agent-node": "3.515.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.2",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.2.0",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"@smithy/util-waiter": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sso": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.515.0.tgz",
+			"integrity": "sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.513.0",
+				"@aws-sdk/middleware-host-header": "3.515.0",
+				"@aws-sdk/middleware-logger": "3.515.0",
+				"@aws-sdk/middleware-recursion-detection": "3.515.0",
+				"@aws-sdk/middleware-user-agent": "3.515.0",
+				"@aws-sdk/region-config-resolver": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@aws-sdk/util-endpoints": "3.515.0",
+				"@aws-sdk/util-user-agent-browser": "3.515.0",
+				"@aws-sdk/util-user-agent-node": "3.515.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.2",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.2.0",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.515.0.tgz",
+			"integrity": "sha512-zACa8LNlPUdlNUBqQRf5a3MfouLNtcBfm84v2c8M976DwJrMGONPe1QjyLLsD38uESQiXiVQRruj/b000iMXNw==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.515.0",
+				"@aws-sdk/core": "3.513.0",
+				"@aws-sdk/middleware-host-header": "3.515.0",
+				"@aws-sdk/middleware-logger": "3.515.0",
+				"@aws-sdk/middleware-recursion-detection": "3.515.0",
+				"@aws-sdk/middleware-user-agent": "3.515.0",
+				"@aws-sdk/region-config-resolver": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@aws-sdk/util-endpoints": "3.515.0",
+				"@aws-sdk/util-user-agent-browser": "3.515.0",
+				"@aws-sdk/util-user-agent-node": "3.515.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.2",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.2.0",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.515.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/client-sts": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.515.0.tgz",
+			"integrity": "sha512-ScYuvaIDgip3atOJIA1FU2n0gJkEdveu1KrrCPathoUCV5zpK8qQmO/n+Fj/7hKFxeKdFbB+4W4CsJWYH94nlg==",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/core": "3.513.0",
+				"@aws-sdk/middleware-host-header": "3.515.0",
+				"@aws-sdk/middleware-logger": "3.515.0",
+				"@aws-sdk/middleware-recursion-detection": "3.515.0",
+				"@aws-sdk/middleware-user-agent": "3.515.0",
+				"@aws-sdk/region-config-resolver": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@aws-sdk/util-endpoints": "3.515.0",
+				"@aws-sdk/util-user-agent-browser": "3.515.0",
+				"@aws-sdk/util-user-agent-node": "3.515.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.2",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.2.0",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": "^3.515.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/core": {
+			"version": "3.513.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.513.0.tgz",
+			"integrity": "sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==",
+			"dependencies": {
+				"@smithy/core": "^1.3.2",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/signature-v4": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.515.0.tgz",
+			"integrity": "sha512-45vxdyqhTAaUMERYVWOziG3K8L2TV9G4ryQS/KZ84o7NAybE9GMdoZRVmGHAO7mJJ1wQiYCM/E+i5b3NW9JfNA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.515.0.tgz",
+			"integrity": "sha512-Ba6FXK77vU4WyheiamNjEuTFmir0eAXuJGPO27lBaA8g+V/seXGHScsbOG14aQGDOr2P02OPwKGZrWWA7BFpfQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-stream": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.515.0.tgz",
+			"integrity": "sha512-ouDlNZdv2TKeVEA/YZk2+XklTXyAAGdbWnl4IgN9ItaodWI+lZjdIoNC8BAooVH+atIV/cZgoGTGQL7j2TxJ9A==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.515.0",
+				"@aws-sdk/credential-provider-env": "3.515.0",
+				"@aws-sdk/credential-provider-process": "3.515.0",
+				"@aws-sdk/credential-provider-sso": "3.515.0",
+				"@aws-sdk/credential-provider-web-identity": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
+			"integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.515.0",
+				"@aws-sdk/credential-provider-http": "3.515.0",
+				"@aws-sdk/credential-provider-ini": "3.515.0",
+				"@aws-sdk/credential-provider-process": "3.515.0",
+				"@aws-sdk/credential-provider-sso": "3.515.0",
+				"@aws-sdk/credential-provider-web-identity": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.515.0.tgz",
+			"integrity": "sha512-pSjiOA2FM63LHRKNDvEpBRp80FVGT0Mw/gzgbqFXP+sewk0WVonYbEcMDTJptH3VsLPGzqH/DQ1YL/aEIBuXFQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.515.0.tgz",
+			"integrity": "sha512-j7vUkiSmuhpBvZYoPTRTI4ePnQbiZMFl6TNhg9b9DprC1zHkucsZnhRhqjOVlrw/H6J4jmcPGcHHTZ5WQNI5xQ==",
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.515.0",
+				"@aws-sdk/token-providers": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.515.0.tgz",
+			"integrity": "sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==",
+			"dependencies": {
+				"@aws-sdk/client-sts": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.515.0.tgz",
+			"integrity": "sha512-I1MwWPzdRKM1luvdDdjdGsDjNVPhj9zaIytEchjTY40NcKOg+p2evLD2y69ozzg8pyXK63r8DdvDGOo9QPuh0A==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.515.0.tgz",
+			"integrity": "sha512-qXomJzg2m/5seQOxHi/yOXOKfSjwrrJSmEmfwJKJyQgdMbBcjz3Cz0H/1LyC6c5hHm6a/SZgSTzDAbAoUmyL+Q==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.515.0.tgz",
+			"integrity": "sha512-dokHLbTV3IHRIBrw9mGoxcNTnQsjlm7TpkJhPdGT9T4Mq399EyQo51u6IsVMm07RXLl2Zw7u+u9p+qWBFzmFRA==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.515.0.tgz",
+			"integrity": "sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@aws-sdk/util-endpoints": "3.515.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.515.0.tgz",
+			"integrity": "sha512-RIRx9loxMgEAc/r1wPfnfShOuzn4RBi8pPPv6/jhhITEeMnJe6enAh2k5y9DdiVDDgCWZgVFSv0YkAIfzAFsnQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/token-providers": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.515.0.tgz",
+			"integrity": "sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==",
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/types": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+			"integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
+			"dependencies": {
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.515.0.tgz",
+			"integrity": "sha512-UJi+jdwcGFV/F7d3+e2aQn5yZOVpDiAgfgNhPnEtgV0WozJ5/ZUeZBgWvSc/K415N4A4D/9cbBc7+I+35qzcDQ==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-endpoints": "^1.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.515.0.tgz",
+			"integrity": "sha512-pTWQb0JCafTmLHLDv3Qqs/nAAJghcPdGQIBpsCStb0YEzg3At/dOi2AIQ683yYnXmeOxLXJDzmlsovfVObJScw==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/types": "^2.9.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.5.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-ses/node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.515.0.tgz",
+			"integrity": "sha512-A/KJ+/HTohHyVXLH+t/bO0Z2mPrQgELbQO8tX+B2nElo8uklj70r5cT7F8ETsI9oOy+HDVpiL5/v45ZgpUOiPg==",
+			"dependencies": {
+				"@aws-sdk/types": "3.515.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
@@ -628,7 +1107,6 @@
 			"version": "3.433.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
 			"integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-			"optional": true,
 			"dependencies": {
 				"@smithy/types": "^2.4.0",
 				"tslib": "^2.5.0"
@@ -655,7 +1133,6 @@
 			"version": "3.310.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
 			"integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -702,7 +1179,6 @@
 			"version": "3.259.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
 			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			}
@@ -972,12 +1448,11 @@
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-			"integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+			"integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -985,15 +1460,32 @@
 			}
 		},
 		"node_modules/@smithy/config-resolver": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
-			"integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+			"integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-config-provider": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.5",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+			"integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
+			"dependencies": {
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1001,15 +1493,14 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
-			"integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+			"integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/types": "^2.4.0",
-				"@smithy/url-parser": "^2.0.12",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1017,39 +1508,36 @@
 			}
 		},
 		"node_modules/@smithy/eventstream-codec": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-			"integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+			"integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
 			"dependencies": {
 				"@aws-crypto/crc32": "3.0.0",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
-			"integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
-			"optional": true,
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+			"integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
 			"dependencies": {
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/querystring-builder": "^2.0.12",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-base64": "^2.0.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/querystring-builder": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-base64": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/hash-node": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
-			"integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+			"integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-buffer-from": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1057,20 +1545,18 @@
 			}
 		},
 		"node_modules/@smithy/invalid-dependency": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-			"integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+			"integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+			"integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -1079,13 +1565,12 @@
 			}
 		},
 		"node_modules/@smithy/middleware-content-length": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-			"integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+			"integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
 			"dependencies": {
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/types": "^2.4.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1093,17 +1578,16 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
-			"integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
-			"optional": true,
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+			"integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
 			"dependencies": {
-				"@smithy/middleware-serde": "^2.0.12",
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/shared-ini-file-loader": "^2.2.2",
-				"@smithy/types": "^2.4.0",
-				"@smithy/url-parser": "^2.0.12",
-				"@smithy/util-middleware": "^2.0.5",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-middleware": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1111,17 +1595,17 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
-			"integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+			"integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/service-error-classification": "^2.0.5",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-middleware": "^2.0.5",
-				"@smithy/util-retry": "^2.0.5",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/service-error-classification": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
 				"tslib": "^2.5.0",
 				"uuid": "^8.3.2"
 			},
@@ -1130,12 +1614,11 @@
 			}
 		},
 		"node_modules/@smithy/middleware-serde": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-			"integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+			"integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1143,12 +1626,11 @@
 			}
 		},
 		"node_modules/@smithy/middleware-stack": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-			"integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+			"integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1156,14 +1638,13 @@
 			}
 		},
 		"node_modules/@smithy/node-config-provider": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
-			"integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+			"integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
 			"dependencies": {
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/shared-ini-file-loader": "^2.2.2",
-				"@smithy/types": "^2.4.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1171,15 +1652,14 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-			"integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
-			"optional": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+			"integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
 			"dependencies": {
-				"@smithy/abort-controller": "^2.0.12",
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/querystring-builder": "^2.0.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/abort-controller": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/querystring-builder": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1187,12 +1667,11 @@
 			}
 		},
 		"node_modules/@smithy/property-provider": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-			"integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+			"integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1200,12 +1679,11 @@
 			}
 		},
 		"node_modules/@smithy/protocol-http": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-			"integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-			"optional": true,
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+			"integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1213,13 +1691,12 @@
 			}
 		},
 		"node_modules/@smithy/querystring-builder": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-			"integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+			"integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-uri-escape": "^2.0.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-uri-escape": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1227,12 +1704,11 @@
 			}
 		},
 		"node_modules/@smithy/querystring-parser": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-			"integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+			"integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1240,24 +1716,22 @@
 			}
 		},
 		"node_modules/@smithy/service-error-classification": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-			"integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+			"integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0"
+				"@smithy/types": "^2.9.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
-			"integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
-			"optional": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+			"integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1265,18 +1739,17 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
-			"integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+			"integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
 			"dependencies": {
-				"@smithy/eventstream-codec": "^2.0.12",
-				"@smithy/is-array-buffer": "^2.0.0",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.5",
-				"@smithy/util-uri-escape": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
+				"@smithy/eventstream-codec": "^2.1.1",
+				"@smithy/is-array-buffer": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-uri-escape": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1284,14 +1757,15 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "2.1.12",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
-			"integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
-			"optional": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+			"integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
 			"dependencies": {
-				"@smithy/middleware-stack": "^2.0.6",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-stream": "^2.0.17",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-stream": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1299,10 +1773,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-			"integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-			"optional": true,
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+			"integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -1311,23 +1784,21 @@
 			}
 		},
 		"node_modules/@smithy/url-parser": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-			"integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+			"integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
 			"dependencies": {
-				"@smithy/querystring-parser": "^2.0.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/querystring-parser": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/util-base64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-			"integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+			"integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1335,19 +1806,17 @@
 			}
 		},
 		"node_modules/@smithy/util-body-length-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-			"integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+			"integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"node_modules/@smithy/util-body-length-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-			"integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+			"integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -1356,12 +1825,11 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+			"integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^2.0.0",
+				"@smithy/is-array-buffer": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1369,10 +1837,9 @@
 			}
 		},
 		"node_modules/@smithy/util-config-provider": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-			"integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+			"integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -1381,14 +1848,13 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
-			"integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+			"integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
 			"dependencies": {
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/smithy-client": "^2.1.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			},
@@ -1397,17 +1863,16 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "2.0.21",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
-			"integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
-			"optional": true,
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+			"integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
 			"dependencies": {
-				"@smithy/config-resolver": "^2.0.16",
-				"@smithy/credential-provider-imds": "^2.0.18",
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/smithy-client": "^2.1.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1415,13 +1880,12 @@
 			}
 		},
 		"node_modules/@smithy/util-endpoints": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
-			"integrity": "sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==",
-			"optional": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+			"integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
 			"dependencies": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/types": "^2.4.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1429,10 +1893,9 @@
 			}
 		},
 		"node_modules/@smithy/util-hex-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-			"integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+			"integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -1441,12 +1904,11 @@
 			}
 		},
 		"node_modules/@smithy/util-middleware": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-			"integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+			"integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
 			"dependencies": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1454,13 +1916,12 @@
 			}
 		},
 		"node_modules/@smithy/util-retry": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-			"integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+			"integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
 			"dependencies": {
-				"@smithy/service-error-classification": "^2.0.5",
-				"@smithy/types": "^2.4.0",
+				"@smithy/service-error-classification": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1468,18 +1929,17 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "2.0.17",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
-			"integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+			"integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^2.2.4",
-				"@smithy/node-http-handler": "^2.1.8",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-base64": "^2.0.0",
-				"@smithy/util-buffer-from": "^2.0.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1487,10 +1947,9 @@
 			}
 		},
 		"node_modules/@smithy/util-uri-escape": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+			"integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
 			"dependencies": {
 				"tslib": "^2.5.0"
 			},
@@ -1499,12 +1958,24 @@
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-			"integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+			"integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"tslib": "^2.5.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-waiter": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+			"integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
+			"dependencies": {
+				"@smithy/abort-controller": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			},
 			"engines": {
@@ -1843,8 +2314,7 @@
 		"node_modules/bowser": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"optional": true
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -3161,7 +3631,6 @@
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"optional": true,
 			"dependencies": {
 				"strnum": "^1.0.5"
 			},
@@ -5421,8 +5890,7 @@
 		"node_modules/strnum": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-			"optional": true
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"node_modules/subarg": {
 			"version": "1.0.0",
@@ -5724,7 +6192,6 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"optional": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -5856,7 +6323,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
 			"integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-			"optional": true,
 			"requires": {
 				"@aws-crypto/util": "^3.0.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -5866,8 +6332,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -5875,7 +6340,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
 			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-			"optional": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -5883,8 +6347,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -5892,7 +6355,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
 			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-			"optional": true,
 			"requires": {
 				"@aws-crypto/ie11-detection": "^3.0.0",
 				"@aws-crypto/sha256-js": "^3.0.0",
@@ -5907,8 +6369,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -5916,7 +6377,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
 			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-			"optional": true,
 			"requires": {
 				"@aws-crypto/util": "^3.0.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -5926,8 +6386,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -5935,7 +6394,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
 			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-			"optional": true,
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -5943,8 +6401,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -5952,7 +6409,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
 			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-			"optional": true,
 			"requires": {
 				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -5962,8 +6418,7 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -6012,6 +6467,421 @@
 				"@smithy/util-retry": "^2.0.5",
 				"@smithy/util-utf8": "^2.0.0",
 				"tslib": "^2.5.0"
+			}
+		},
+		"@aws-sdk/client-ses": {
+			"version": "3.515.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.515.0.tgz",
+			"integrity": "sha512-X51TvcpqJ83ZOSUa/efWl+cj3cXBF6fCb2iNghjRD2McDvzGKoiR+Zaoy05doPdh/GZ7azTBqX0qKRIyUj//wg==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.515.0",
+				"@aws-sdk/core": "3.513.0",
+				"@aws-sdk/credential-provider-node": "3.515.0",
+				"@aws-sdk/middleware-host-header": "3.515.0",
+				"@aws-sdk/middleware-logger": "3.515.0",
+				"@aws-sdk/middleware-recursion-detection": "3.515.0",
+				"@aws-sdk/middleware-user-agent": "3.515.0",
+				"@aws-sdk/region-config-resolver": "3.515.0",
+				"@aws-sdk/types": "3.515.0",
+				"@aws-sdk/util-endpoints": "3.515.0",
+				"@aws-sdk/util-user-agent-browser": "3.515.0",
+				"@aws-sdk/util-user-agent-node": "3.515.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/core": "^1.3.2",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/hash-node": "^2.1.1",
+				"@smithy/invalid-dependency": "^2.1.1",
+				"@smithy/middleware-content-length": "^2.1.1",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-body-length-browser": "^2.1.1",
+				"@smithy/util-body-length-node": "^2.2.1",
+				"@smithy/util-defaults-mode-browser": "^2.1.1",
+				"@smithy/util-defaults-mode-node": "^2.2.0",
+				"@smithy/util-endpoints": "^1.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
+				"@smithy/util-waiter": "^2.1.1",
+				"fast-xml-parser": "4.2.5",
+				"tslib": "^2.5.0"
+			},
+			"dependencies": {
+				"@aws-sdk/client-sso": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.515.0.tgz",
+					"integrity": "sha512-4oGBLW476zmkdN98lAns3bObRNO+DLOfg4MDUSR6l6GYBV/zGAtoy2O/FhwYKgA2L5h2ZtElGopLlk/1Q0ePLw==",
+					"requires": {
+						"@aws-crypto/sha256-browser": "3.0.0",
+						"@aws-crypto/sha256-js": "3.0.0",
+						"@aws-sdk/core": "3.513.0",
+						"@aws-sdk/middleware-host-header": "3.515.0",
+						"@aws-sdk/middleware-logger": "3.515.0",
+						"@aws-sdk/middleware-recursion-detection": "3.515.0",
+						"@aws-sdk/middleware-user-agent": "3.515.0",
+						"@aws-sdk/region-config-resolver": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@aws-sdk/util-endpoints": "3.515.0",
+						"@aws-sdk/util-user-agent-browser": "3.515.0",
+						"@aws-sdk/util-user-agent-node": "3.515.0",
+						"@smithy/config-resolver": "^2.1.1",
+						"@smithy/core": "^1.3.2",
+						"@smithy/fetch-http-handler": "^2.4.1",
+						"@smithy/hash-node": "^2.1.1",
+						"@smithy/invalid-dependency": "^2.1.1",
+						"@smithy/middleware-content-length": "^2.1.1",
+						"@smithy/middleware-endpoint": "^2.4.1",
+						"@smithy/middleware-retry": "^2.1.1",
+						"@smithy/middleware-serde": "^2.1.1",
+						"@smithy/middleware-stack": "^2.1.1",
+						"@smithy/node-config-provider": "^2.2.1",
+						"@smithy/node-http-handler": "^2.3.1",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/smithy-client": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"@smithy/url-parser": "^2.1.1",
+						"@smithy/util-base64": "^2.1.1",
+						"@smithy/util-body-length-browser": "^2.1.1",
+						"@smithy/util-body-length-node": "^2.2.1",
+						"@smithy/util-defaults-mode-browser": "^2.1.1",
+						"@smithy/util-defaults-mode-node": "^2.2.0",
+						"@smithy/util-endpoints": "^1.1.1",
+						"@smithy/util-middleware": "^2.1.1",
+						"@smithy/util-retry": "^2.1.1",
+						"@smithy/util-utf8": "^2.1.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/client-sso-oidc": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.515.0.tgz",
+					"integrity": "sha512-zACa8LNlPUdlNUBqQRf5a3MfouLNtcBfm84v2c8M976DwJrMGONPe1QjyLLsD38uESQiXiVQRruj/b000iMXNw==",
+					"requires": {
+						"@aws-crypto/sha256-browser": "3.0.0",
+						"@aws-crypto/sha256-js": "3.0.0",
+						"@aws-sdk/client-sts": "3.515.0",
+						"@aws-sdk/core": "3.513.0",
+						"@aws-sdk/middleware-host-header": "3.515.0",
+						"@aws-sdk/middleware-logger": "3.515.0",
+						"@aws-sdk/middleware-recursion-detection": "3.515.0",
+						"@aws-sdk/middleware-user-agent": "3.515.0",
+						"@aws-sdk/region-config-resolver": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@aws-sdk/util-endpoints": "3.515.0",
+						"@aws-sdk/util-user-agent-browser": "3.515.0",
+						"@aws-sdk/util-user-agent-node": "3.515.0",
+						"@smithy/config-resolver": "^2.1.1",
+						"@smithy/core": "^1.3.2",
+						"@smithy/fetch-http-handler": "^2.4.1",
+						"@smithy/hash-node": "^2.1.1",
+						"@smithy/invalid-dependency": "^2.1.1",
+						"@smithy/middleware-content-length": "^2.1.1",
+						"@smithy/middleware-endpoint": "^2.4.1",
+						"@smithy/middleware-retry": "^2.1.1",
+						"@smithy/middleware-serde": "^2.1.1",
+						"@smithy/middleware-stack": "^2.1.1",
+						"@smithy/node-config-provider": "^2.2.1",
+						"@smithy/node-http-handler": "^2.3.1",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/smithy-client": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"@smithy/url-parser": "^2.1.1",
+						"@smithy/util-base64": "^2.1.1",
+						"@smithy/util-body-length-browser": "^2.1.1",
+						"@smithy/util-body-length-node": "^2.2.1",
+						"@smithy/util-defaults-mode-browser": "^2.1.1",
+						"@smithy/util-defaults-mode-node": "^2.2.0",
+						"@smithy/util-endpoints": "^1.1.1",
+						"@smithy/util-middleware": "^2.1.1",
+						"@smithy/util-retry": "^2.1.1",
+						"@smithy/util-utf8": "^2.1.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/client-sts": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.515.0.tgz",
+					"integrity": "sha512-ScYuvaIDgip3atOJIA1FU2n0gJkEdveu1KrrCPathoUCV5zpK8qQmO/n+Fj/7hKFxeKdFbB+4W4CsJWYH94nlg==",
+					"requires": {
+						"@aws-crypto/sha256-browser": "3.0.0",
+						"@aws-crypto/sha256-js": "3.0.0",
+						"@aws-sdk/core": "3.513.0",
+						"@aws-sdk/middleware-host-header": "3.515.0",
+						"@aws-sdk/middleware-logger": "3.515.0",
+						"@aws-sdk/middleware-recursion-detection": "3.515.0",
+						"@aws-sdk/middleware-user-agent": "3.515.0",
+						"@aws-sdk/region-config-resolver": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@aws-sdk/util-endpoints": "3.515.0",
+						"@aws-sdk/util-user-agent-browser": "3.515.0",
+						"@aws-sdk/util-user-agent-node": "3.515.0",
+						"@smithy/config-resolver": "^2.1.1",
+						"@smithy/core": "^1.3.2",
+						"@smithy/fetch-http-handler": "^2.4.1",
+						"@smithy/hash-node": "^2.1.1",
+						"@smithy/invalid-dependency": "^2.1.1",
+						"@smithy/middleware-content-length": "^2.1.1",
+						"@smithy/middleware-endpoint": "^2.4.1",
+						"@smithy/middleware-retry": "^2.1.1",
+						"@smithy/middleware-serde": "^2.1.1",
+						"@smithy/middleware-stack": "^2.1.1",
+						"@smithy/node-config-provider": "^2.2.1",
+						"@smithy/node-http-handler": "^2.3.1",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/smithy-client": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"@smithy/url-parser": "^2.1.1",
+						"@smithy/util-base64": "^2.1.1",
+						"@smithy/util-body-length-browser": "^2.1.1",
+						"@smithy/util-body-length-node": "^2.2.1",
+						"@smithy/util-defaults-mode-browser": "^2.1.1",
+						"@smithy/util-defaults-mode-node": "^2.2.0",
+						"@smithy/util-endpoints": "^1.1.1",
+						"@smithy/util-middleware": "^2.1.1",
+						"@smithy/util-retry": "^2.1.1",
+						"@smithy/util-utf8": "^2.1.1",
+						"fast-xml-parser": "4.2.5",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/core": {
+					"version": "3.513.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.513.0.tgz",
+					"integrity": "sha512-L+9DL4apWuqNKVOMJ8siAuWoRM9rZf9w1iPv8S2o83WO2jVK7E/m+rNW1dFo9HsA5V1ccDl2H2qLXx24HiHmOw==",
+					"requires": {
+						"@smithy/core": "^1.3.2",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/signature-v4": "^2.1.1",
+						"@smithy/smithy-client": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-env": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.515.0.tgz",
+					"integrity": "sha512-45vxdyqhTAaUMERYVWOziG3K8L2TV9G4ryQS/KZ84o7NAybE9GMdoZRVmGHAO7mJJ1wQiYCM/E+i5b3NW9JfNA==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-http": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.515.0.tgz",
+					"integrity": "sha512-Ba6FXK77vU4WyheiamNjEuTFmir0eAXuJGPO27lBaA8g+V/seXGHScsbOG14aQGDOr2P02OPwKGZrWWA7BFpfQ==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/fetch-http-handler": "^2.4.1",
+						"@smithy/node-http-handler": "^2.3.1",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/smithy-client": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"@smithy/util-stream": "^2.1.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-ini": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.515.0.tgz",
+					"integrity": "sha512-ouDlNZdv2TKeVEA/YZk2+XklTXyAAGdbWnl4IgN9ItaodWI+lZjdIoNC8BAooVH+atIV/cZgoGTGQL7j2TxJ9A==",
+					"requires": {
+						"@aws-sdk/client-sts": "3.515.0",
+						"@aws-sdk/credential-provider-env": "3.515.0",
+						"@aws-sdk/credential-provider-process": "3.515.0",
+						"@aws-sdk/credential-provider-sso": "3.515.0",
+						"@aws-sdk/credential-provider-web-identity": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/credential-provider-imds": "^2.2.1",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/shared-ini-file-loader": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-node": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.515.0.tgz",
+					"integrity": "sha512-Y4kHSpbxksiCZZNcvsiKUd8Fb2XlyUuONEwqWFNL82ZH6TCCjBGS31wJQCSxBHqYcOL3tiORUEJkoO7uS30uQA==",
+					"requires": {
+						"@aws-sdk/credential-provider-env": "3.515.0",
+						"@aws-sdk/credential-provider-http": "3.515.0",
+						"@aws-sdk/credential-provider-ini": "3.515.0",
+						"@aws-sdk/credential-provider-process": "3.515.0",
+						"@aws-sdk/credential-provider-sso": "3.515.0",
+						"@aws-sdk/credential-provider-web-identity": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/credential-provider-imds": "^2.2.1",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/shared-ini-file-loader": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-process": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.515.0.tgz",
+					"integrity": "sha512-pSjiOA2FM63LHRKNDvEpBRp80FVGT0Mw/gzgbqFXP+sewk0WVonYbEcMDTJptH3VsLPGzqH/DQ1YL/aEIBuXFQ==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/shared-ini-file-loader": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-sso": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.515.0.tgz",
+					"integrity": "sha512-j7vUkiSmuhpBvZYoPTRTI4ePnQbiZMFl6TNhg9b9DprC1zHkucsZnhRhqjOVlrw/H6J4jmcPGcHHTZ5WQNI5xQ==",
+					"requires": {
+						"@aws-sdk/client-sso": "3.515.0",
+						"@aws-sdk/token-providers": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/shared-ini-file-loader": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/credential-provider-web-identity": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.515.0.tgz",
+					"integrity": "sha512-66+2g4z3fWwdoGReY8aUHvm6JrKZMTRxjuizljVmMyOBttKPeBYXvUTop/g3ZGUx1f8j+C5qsGK52viYBvtjuQ==",
+					"requires": {
+						"@aws-sdk/client-sts": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/middleware-host-header": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.515.0.tgz",
+					"integrity": "sha512-I1MwWPzdRKM1luvdDdjdGsDjNVPhj9zaIytEchjTY40NcKOg+p2evLD2y69ozzg8pyXK63r8DdvDGOo9QPuh0A==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/middleware-logger": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.515.0.tgz",
+					"integrity": "sha512-qXomJzg2m/5seQOxHi/yOXOKfSjwrrJSmEmfwJKJyQgdMbBcjz3Cz0H/1LyC6c5hHm6a/SZgSTzDAbAoUmyL+Q==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/middleware-recursion-detection": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.515.0.tgz",
+					"integrity": "sha512-dokHLbTV3IHRIBrw9mGoxcNTnQsjlm7TpkJhPdGT9T4Mq399EyQo51u6IsVMm07RXLl2Zw7u+u9p+qWBFzmFRA==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/middleware-user-agent": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.515.0.tgz",
+					"integrity": "sha512-nOqZjGA/GkjuJ5fUshec9Fv6HFd7ovOTxMJbw3MfAhqXuVZ6dKF41lpVJ4imNsgyFt3shUg9WDY8zGFjlYMB3g==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@aws-sdk/util-endpoints": "3.515.0",
+						"@smithy/protocol-http": "^3.1.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/region-config-resolver": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.515.0.tgz",
+					"integrity": "sha512-RIRx9loxMgEAc/r1wPfnfShOuzn4RBi8pPPv6/jhhITEeMnJe6enAh2k5y9DdiVDDgCWZgVFSv0YkAIfzAFsnQ==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/node-config-provider": "^2.2.1",
+						"@smithy/types": "^2.9.1",
+						"@smithy/util-config-provider": "^2.2.1",
+						"@smithy/util-middleware": "^2.1.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/token-providers": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.515.0.tgz",
+					"integrity": "sha512-MQuf04rIcTXqwDzmyHSpFPF1fKEzRl64oXtCRUF3ddxTdK6wxXkePfK6wNCuL+GEbEcJAoCtIGIRpzGPJvQjHA==",
+					"requires": {
+						"@aws-sdk/client-sso-oidc": "3.515.0",
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/property-provider": "^2.1.1",
+						"@smithy/shared-ini-file-loader": "^2.3.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/types": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+					"integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
+					"requires": {
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/util-endpoints": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.515.0.tgz",
+					"integrity": "sha512-UJi+jdwcGFV/F7d3+e2aQn5yZOVpDiAgfgNhPnEtgV0WozJ5/ZUeZBgWvSc/K415N4A4D/9cbBc7+I+35qzcDQ==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/types": "^2.9.1",
+						"@smithy/util-endpoints": "^1.1.1",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/util-user-agent-browser": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.515.0.tgz",
+					"integrity": "sha512-pTWQb0JCafTmLHLDv3Qqs/nAAJghcPdGQIBpsCStb0YEzg3At/dOi2AIQ683yYnXmeOxLXJDzmlsovfVObJScw==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/types": "^2.9.1",
+						"bowser": "^2.11.0",
+						"tslib": "^2.5.0"
+					}
+				},
+				"@aws-sdk/util-user-agent-node": {
+					"version": "3.515.0",
+					"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.515.0.tgz",
+					"integrity": "sha512-A/KJ+/HTohHyVXLH+t/bO0Z2mPrQgELbQO8tX+B2nElo8uklj70r5cT7F8ETsI9oOy+HDVpiL5/v45ZgpUOiPg==",
+					"requires": {
+						"@aws-sdk/types": "3.515.0",
+						"@smithy/node-config-provider": "^2.2.1",
+						"@smithy/types": "^2.9.1",
+						"tslib": "^2.5.0"
+					}
+				}
 			}
 		},
 		"@aws-sdk/client-sso": {
@@ -6395,7 +7265,6 @@
 			"version": "3.433.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
 			"integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
-			"optional": true,
 			"requires": {
 				"@smithy/types": "^2.4.0",
 				"tslib": "^2.5.0"
@@ -6416,7 +7285,6 @@
 			"version": "3.310.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
 			"integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.5.0"
 			}
@@ -6449,7 +7317,6 @@
 			"version": "3.259.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
 			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -6661,440 +7528,429 @@
 			"integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
 		},
 		"@smithy/abort-controller": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.12.tgz",
-			"integrity": "sha512-YIJyefe1mi3GxKdZxEBEuzYOeQ9xpYfqnFmWzojCssRAuR7ycxwpoRQgp965vuW426xUAQhCV5rCaWElQ7XsaA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+			"integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/config-resolver": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.16.tgz",
-			"integrity": "sha512-1k+FWHQDt2pfpXhJsOmNMmlAZ3NUQ98X5tYsjQhVGq+0X6cOBMhfh6Igd0IX3Ut6lEO6DQAdPMI/blNr3JZfMQ==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+			"integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
 			"requires": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-config-provider": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.5",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-config-provider": "^2.2.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"@smithy/core": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.2.tgz",
+			"integrity": "sha512-tYDmTp0f2TZVE18jAOH1PnmkngLQ+dOGUlMd1u67s87ieueNeyqhja6z/Z4MxhybEiXKOWFOmGjfTZWFxljwJw==",
+			"requires": {
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-retry": "^2.1.1",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/credential-provider-imds": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.18.tgz",
-			"integrity": "sha512-QnPBi6D2zj6AHJdUTo5zXmk8vwHJ2bNevhcVned1y+TZz/OI5cizz5DsYNkqFUIDn8tBuEyKNgbmKVNhBbuY3g==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+			"integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
 			"requires": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/types": "^2.4.0",
-				"@smithy/url-parser": "^2.0.12",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/eventstream-codec": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.12.tgz",
-			"integrity": "sha512-ZZQLzHBJkbiAAdj2C5K+lBlYp/XJ+eH2uy+jgJgYIFW/o5AM59Hlj7zyI44/ZTDIQWmBxb3EFv/c5t44V8/g8A==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+			"integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
 			"requires": {
 				"@aws-crypto/crc32": "3.0.0",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/fetch-http-handler": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.2.4.tgz",
-			"integrity": "sha512-gIPRFEGi+c6V52eauGKrjDzPWF2Cu7Z1r5F8A3j2wcwz25sPG/t8kjsbEhli/tS/2zJp/ybCZXe4j4ro3yv/HA==",
-			"optional": true,
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+			"integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
 			"requires": {
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/querystring-builder": "^2.0.12",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-base64": "^2.0.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/querystring-builder": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-base64": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/hash-node": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.12.tgz",
-			"integrity": "sha512-fDZnTr5j9t5qcbeJ037aMZXxMka13Znqwrgy3PAqYj6Dm3XHXHftTH3q+NWgayUxl1992GFtQt1RuEzRMy3NnQ==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+			"integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-buffer-from": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/invalid-dependency": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.12.tgz",
-			"integrity": "sha512-p5Y+iMHV3SoEpy3VSR7mifbreHQwVSvHSAz/m4GdoXfOzKzaYC8hYv10Ks7Deblkf7lhas8U+lAp9ThbBM+ZXA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+			"integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/is-array-buffer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-			"integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+			"integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-content-length": {
-			"version": "2.0.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.14.tgz",
-			"integrity": "sha512-poUNgKTw9XwPXfX9nEHpVgrMNVpaSMZbshqvPxFVoalF4wp6kRzYKOfdesSVectlQ51VtigoLfbXcdyPwvxgTg==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+			"integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
 			"requires": {
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/types": "^2.4.0",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-endpoint": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.1.3.tgz",
-			"integrity": "sha512-ZrQ0/YX6hNVTxqMEHtEaDbDv6pNeEji/a5Vk3HuFC5R3ZY8lfoATyxmOGxBVYnF3NUvZLNC7umEv1WzWGWvCGQ==",
-			"optional": true,
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+			"integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
 			"requires": {
-				"@smithy/middleware-serde": "^2.0.12",
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/shared-ini-file-loader": "^2.2.2",
-				"@smithy/types": "^2.4.0",
-				"@smithy/url-parser": "^2.0.12",
-				"@smithy/util-middleware": "^2.0.5",
+				"@smithy/middleware-serde": "^2.1.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/url-parser": "^2.1.1",
+				"@smithy/util-middleware": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-retry": {
-			"version": "2.0.18",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.18.tgz",
-			"integrity": "sha512-VyrHQRldGSb3v9oFOB5yPxmLT7U2sQic2ytylOnYlnsmVOLlFIaI6sW22c+w2675yq+XZ6HOuzV7x2OBYCWRNA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+			"integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
 			"requires": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/service-error-classification": "^2.0.5",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-middleware": "^2.0.5",
-				"@smithy/util-retry": "^2.0.5",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/service-error-classification": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-retry": "^2.1.1",
 				"tslib": "^2.5.0",
 				"uuid": "^8.3.2"
 			}
 		},
 		"@smithy/middleware-serde": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.12.tgz",
-			"integrity": "sha512-IBeco157lIScecq2Z+n0gq56i4MTnfKxS7rbfrAORveDJgnbBAaEQgYqMqp/cYqKrpvEXcyTjwKHrBjCCIZh2A==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+			"integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/middleware-stack": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.6.tgz",
-			"integrity": "sha512-YSvNZeOKWLJ0M/ycxwDIe2Ztkp6Qixmcml1ggsSv2fdHKGkBPhGrX5tMzPGMI1yyx55UEYBi2OB4s+RriXX48A==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+			"integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/node-config-provider": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.3.tgz",
-			"integrity": "sha512-J6lXvRHGVnSX3n1PYi+e1L5HN73DkkJpUviV3Ebf+8wSaIjAf+eVNbzyvh/S5EQz7nf4KVfwbD5vdoZMAthAEQ==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+			"integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
 			"requires": {
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/shared-ini-file-loader": "^2.2.2",
-				"@smithy/types": "^2.4.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/shared-ini-file-loader": "^2.3.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/node-http-handler": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.1.8.tgz",
-			"integrity": "sha512-KZylM7Wff/So5SmCiwg2kQNXJ+RXgz34wkxS7WNwIUXuZrZZpY/jKJCK+ZaGyuESDu3TxcaY+zeYGJmnFKbQsA==",
-			"optional": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+			"integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
 			"requires": {
-				"@smithy/abort-controller": "^2.0.12",
-				"@smithy/protocol-http": "^3.0.8",
-				"@smithy/querystring-builder": "^2.0.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/abort-controller": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/querystring-builder": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/property-provider": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.13.tgz",
-			"integrity": "sha512-VJqUf2CbsQX6uUiC5dUPuoEATuFjkbkW3lJHbRnpk9EDC9X+iKqhfTK+WP+lve5EQ9TcCI1Q6R7hrg41FyC54w==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+			"integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/protocol-http": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.8.tgz",
-			"integrity": "sha512-SHJvYeWq8q0FK8xHk+xjV9dzDUDjFMT+G1pZbV+XB6OVoac/FSVshlMNPeUJ8AmSkcDKHRu5vASnRqZHgD3qhw==",
-			"optional": true,
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+			"integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/querystring-builder": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.12.tgz",
-			"integrity": "sha512-cDbF07IuCjiN8CdGvPzfJjXIrmDSelScRfyJYrYBNBbKl2+k7QD/KqiHhtRyEKgID5mmEVrV6KE6L/iPJ98sFw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+			"integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-uri-escape": "^2.0.0",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-uri-escape": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/querystring-parser": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.12.tgz",
-			"integrity": "sha512-fytyTcXaMzPBuNtPlhj5v6dbl4bJAnwKZFyyItAGt4Tgm9HFPZNo7a9r1SKPr/qdxUEBzvL9Rh+B9SkTX3kFxg==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+			"integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/service-error-classification": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.5.tgz",
-			"integrity": "sha512-M0SeJnEgD2ywJyV99Fb1yKFzmxDe9JfpJiYTVSRMyRLc467BPU0qsuuDPzMCdB1mU8M8u1rVOdkqdoyFN8UFTw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+			"integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
 			"requires": {
-				"@smithy/types": "^2.4.0"
+				"@smithy/types": "^2.9.1"
 			}
 		},
 		"@smithy/shared-ini-file-loader": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.2.tgz",
-			"integrity": "sha512-noyQUPn7b1M8uB0GEXc/Zyxq+5K2b7aaqWnLp+hgJ7+xu/FCvtyWy5eWLDjQEsHnAet2IZhS5QF8872OR69uNg==",
-			"optional": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+			"integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/signature-v4": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.12.tgz",
-			"integrity": "sha512-6Kc2lCZEVmb1nNYngyNbWpq0d82OZwITH11SW/Q0U6PX5fH7B2cIcFe7o6eGEFPkTZTP8itTzmYiGcECL0D0Lw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+			"integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
 			"requires": {
-				"@smithy/eventstream-codec": "^2.0.12",
-				"@smithy/is-array-buffer": "^2.0.0",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-middleware": "^2.0.5",
-				"@smithy/util-uri-escape": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
+				"@smithy/eventstream-codec": "^2.1.1",
+				"@smithy/is-array-buffer": "^2.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-middleware": "^2.1.1",
+				"@smithy/util-uri-escape": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/smithy-client": {
-			"version": "2.1.12",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.1.12.tgz",
-			"integrity": "sha512-XXqhridfkKnpj+lt8vM6HRlZbqUAqBjVC74JIi13F/AYQd/zTj9SOyGfxnbp4mjY9q28LityxIuV8CTinr9r5w==",
-			"optional": true,
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+			"integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
 			"requires": {
-				"@smithy/middleware-stack": "^2.0.6",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-stream": "^2.0.17",
+				"@smithy/middleware-endpoint": "^2.4.1",
+				"@smithy/middleware-stack": "^2.1.1",
+				"@smithy/protocol-http": "^3.1.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-stream": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/types": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.4.0.tgz",
-			"integrity": "sha512-iH1Xz68FWlmBJ9vvYeHifVMWJf82ONx+OybPW8ZGf5wnEv2S0UXcU4zwlwJkRXuLKpcSLHrraHbn2ucdVXLb4g==",
-			"optional": true,
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+			"integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/url-parser": {
-			"version": "2.0.12",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.12.tgz",
-			"integrity": "sha512-qgkW2mZqRvlNUcBkxYB/gYacRaAdck77Dk3/g2iw0S9F0EYthIS3loGfly8AwoWpIvHKhkTsCXXQfzksgZ4zIA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+			"integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
 			"requires": {
-				"@smithy/querystring-parser": "^2.0.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/querystring-parser": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-base64": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-			"integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+			"integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
 			"requires": {
-				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-body-length-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-			"integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+			"integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-body-length-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-			"integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+			"integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-buffer-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-			"integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+			"integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
 			"requires": {
-				"@smithy/is-array-buffer": "^2.0.0",
+				"@smithy/is-array-buffer": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-config-provider": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-			"integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
-			"optional": true,
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+			"integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-defaults-mode-browser": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.16.tgz",
-			"integrity": "sha512-Uv5Cu8nVkuvLn0puX+R9zWbSNpLIR3AxUlPoLJ7hC5lvir8B2WVqVEkJLwtixKAncVLasnTVjPDCidtAUTGEQw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+			"integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
 			"requires": {
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/smithy-client": "^2.1.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-defaults-mode-node": {
-			"version": "2.0.21",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.21.tgz",
-			"integrity": "sha512-cUEsttVZ79B7Al2rWK2FW03HBpD9LyuqFtm+1qFty5u9sHSdesr215gS2Ln53fTopNiPgeXpdoM3IgjvIO0rJw==",
-			"optional": true,
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.0.tgz",
+			"integrity": "sha512-iFJp/N4EtkanFpBUtSrrIbtOIBf69KNuve03ic1afhJ9/korDxdM0c6cCH4Ehj/smI9pDCfVv+bqT3xZjF2WaA==",
 			"requires": {
-				"@smithy/config-resolver": "^2.0.16",
-				"@smithy/credential-provider-imds": "^2.0.18",
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/property-provider": "^2.0.13",
-				"@smithy/smithy-client": "^2.1.12",
-				"@smithy/types": "^2.4.0",
+				"@smithy/config-resolver": "^2.1.1",
+				"@smithy/credential-provider-imds": "^2.2.1",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/property-provider": "^2.1.1",
+				"@smithy/smithy-client": "^2.3.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-endpoints": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.2.tgz",
-			"integrity": "sha512-QEdq+sP68IJHAMVB2ugKVVZEWeKQtZLuf+akHzc8eTVElsZ2ZdVLWC6Cp+uKjJ/t4yOj1qu6ZzyxJQEQ8jdEjg==",
-			"optional": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+			"integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
 			"requires": {
-				"@smithy/node-config-provider": "^2.1.3",
-				"@smithy/types": "^2.4.0",
+				"@smithy/node-config-provider": "^2.2.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-hex-encoding": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-			"integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+			"integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-middleware": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.5.tgz",
-			"integrity": "sha512-1lyT3TcaMJQe+OFfVI+TlomDkPuVzb27NZYdYtmSTltVmLaUjdCyt4KE+OH1CnhZKsz4/cdCL420Lg9UH5Z2Mw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+			"integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
 			"requires": {
-				"@smithy/types": "^2.4.0",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-retry": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.5.tgz",
-			"integrity": "sha512-x3t1+MQAJ6QONk3GTbJNcugCFDVJ+Bkro5YqQQK1EyVesajNDqxFtCx9WdOFNGm/Cbm7tUdwVEmfKQOJoU2Vtw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+			"integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
 			"requires": {
-				"@smithy/service-error-classification": "^2.0.5",
-				"@smithy/types": "^2.4.0",
+				"@smithy/service-error-classification": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-stream": {
-			"version": "2.0.17",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.17.tgz",
-			"integrity": "sha512-fP/ZQ27rRvHsqItds8yB7jerwMpZFTL3QqbQbidUiG0+mttMoKdP0ZqnvM8UK5q0/dfc3/pN7g4XKPXOU7oRWw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+			"integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
 			"requires": {
-				"@smithy/fetch-http-handler": "^2.2.4",
-				"@smithy/node-http-handler": "^2.1.8",
-				"@smithy/types": "^2.4.0",
-				"@smithy/util-base64": "^2.0.0",
-				"@smithy/util-buffer-from": "^2.0.0",
-				"@smithy/util-hex-encoding": "^2.0.0",
-				"@smithy/util-utf8": "^2.0.0",
+				"@smithy/fetch-http-handler": "^2.4.1",
+				"@smithy/node-http-handler": "^2.3.1",
+				"@smithy/types": "^2.9.1",
+				"@smithy/util-base64": "^2.1.1",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"@smithy/util-hex-encoding": "^2.1.1",
+				"@smithy/util-utf8": "^2.1.1",
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-uri-escape": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-			"integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+			"integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
 			"requires": {
 				"tslib": "^2.5.0"
 			}
 		},
 		"@smithy/util-utf8": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-			"integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
-			"optional": true,
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+			"integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
 			"requires": {
-				"@smithy/util-buffer-from": "^2.0.0",
+				"@smithy/util-buffer-from": "^2.1.1",
+				"tslib": "^2.5.0"
+			}
+		},
+		"@smithy/util-waiter": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+			"integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
+			"requires": {
+				"@smithy/abort-controller": "^2.1.1",
+				"@smithy/types": "^2.9.1",
 				"tslib": "^2.5.0"
 			}
 		},
@@ -7369,8 +8225,7 @@
 		"bowser": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"optional": true
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -8420,7 +9275,6 @@
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
 			"integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-			"optional": true,
 			"requires": {
 				"strnum": "^1.0.5"
 			}
@@ -10110,8 +10964,7 @@
 		"strnum": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-			"optional": true
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"subarg": {
 			"version": "1.0.0",
@@ -10358,8 +11211,7 @@
 		"uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"optional": true
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 	},
 	"homepage": "https://github.com/PretendoNetwork/website#readme",
 	"dependencies": {
+		"@aws-sdk/client-ses": "^3.515.0",
 		"@discordjs/rest": "^0.5.0",
 		"browserify": "^17.0.0",
 		"colors": "^1.4.0",


### PR DESCRIPTION
Moves the email sending away from abusing gmail "less secure apps" to a proper email service. Account server PR is also pending.

Do not merge until AWS accepts our request for production use of SES.

One of our goals here is to make our servers platform-agnostic, not relying on any one vendor to prevent vendor lock-in. Vendor lock-in makes rehosting our servers difficult for some people.

That being said, these changes are import enough to just push through as-is. We can work out the details of making email sending more generalized at a later date.