### PR TITLE
Update 3ds.md

### DIFF
--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -91,6 +91,8 @@ Setting up a PNID on the 3DS is the same as setting up a NNID. You may either cr
 
 It is recommended to register the PNID on your device at this time, as registering on the website does not currently allow you to change your user data
 
+CAUTION: A Pretendo Network ID may not be the same as the one currently linked to your 3ds, ensure that your PNID and NNID do not match before you make it.
+
 ## Other information
 
 ### How does Nimbus work?

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -91,7 +91,11 @@ Setting up a PNID on the 3DS is the same as setting up a NNID. You may either cr
 
 It is recommended to register the PNID on your device at this time, as registering on the website does not currently allow you to change your user data
 
-CAUTION: A Pretendo Network ID may not be the same as the one currently linked to your 3ds, ensure that your PNID and NNID do not match before you make it.
+<div class="tip red">
+	<strong>CAUTION:</strong>
+	A Pretendo Network ID may not use the same username as the account already linked to your 3ds! Ensure that you have a choose a different name for your PNID than the name on your NNID
+</div>
+
 
 ## Other information
 

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -93,7 +93,7 @@ It is recommended to register the PNID on your device at this time, as registeri
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	A Pretendo Network ID may not use the same username as the account already linked to your 3ds! Ensure that you have a choose a different name for your PNID than the name on your NNID
+	A Pretendo Network ID may not use the same username as the account already linked to your 3DS! Ensure that you have a choose a different name for your PNID than the name on your NNID
 </div>
 
 


### PR DESCRIPTION
Added a warning to tell users not to make the NNID and PNID the same, since the wii u install doc had the warning but the 3ds was missing it, causing some users to accidentally create an account with the same details as their NNID