### PR TITLE
3DS Docs: Add Badge removal warning

### DIFF
--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -123,4 +123,7 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 12. Select `Save As` to save the modified file separately from the backup.
 13. Put your SD card back into your 3DS and go back into SBI
 14. Inject your modified badge data files.
+
+All badges on the home menu will be deleted, and you have to re-add them in the order you have had them before.
+    
 If you encounter any errors, restore your backed up badge data through SBI. Injecting badges while using Pretendo Network will make them disappear when swapping back to Nintendo Network, and vice versa.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -7,7 +7,7 @@
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	Launching Nintendo Badge Arcade while connected to one network with badges obtained while connected to the other will cause your local save data to not match your server save data. This will cause your badges to disappear.
+	Collecting badges in Nintendo Badge Arcade while connected to one network and then launching the game on a different network will result in your badges disappearing. This occurs because the locally saved data does not match the data stored on the server.
 </div>
 
 <div class="tip">

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -110,7 +110,7 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 	<li id="footnote-1"><sup>[1]</sup> Some games may require a PNID for certain actions, such as eShop purchases. The only known game which requires a PNID for general use is Nintendo Badge Arcade, which is not yet supported</li>
 </ul>
 
-### What do I do if my console says that my badges get erased?
+### What do I do if the Home Menu says I have no badges after switching?
 Follow these steps.
 
 1. Insert your SD Card into your PC

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -117,7 +117,7 @@ Follow these steps.
 
 2. Back up your badges at the folder on your SD Card "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place on your device.
 
-[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 1 or 2. just in case this doesn't work.
+[ID0] and [ID1] are place holders, the actual folder names will be 32 characters.
 
 3. Install [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)) on your 3DS console
 
@@ -136,3 +136,5 @@ Follow these steps.
 10. Save the file. It might be a good idea to choose "Save As" and then save them into a different folder so you can separate them into Pretendo and Nintendo versions.
 
 11. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)
+
+This will remove badges from your Nintendo Network accouint, but all badges will be intact on Pretendo Network.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -7,9 +7,7 @@
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS\[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place.
-
-[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 0 or 1.
+	Launching Nintendo Badge Arcade while connected to one network with badges obtained while connected to the other will cause your local save data to not match your server save data. This will cause your badges to disappear.
 </div>
 
 <div class="tip">
@@ -110,31 +108,19 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 	<li id="footnote-1"><sup>[1]</sup> Some games may require a PNID for certain actions, such as eShop purchases. The only known game which requires a PNID for general use is Nintendo Badge Arcade, which is not yet supported</li>
 </ul>
 
-### What do I do if the Home Menu says I have no badges after switching?
-Follow these steps.
-
-1. Insert your SD Card into your PC
-
-2. Back up your badges at the folder on your SD Card "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place on your device.
-
-[ID0] and [ID1] are place holders, the actual folder names will be 32 characters.
-
-3. Install [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)) on your 3DS console
-
+### Restoring Nintendo Badge Arcade Badges
+1. Insert your SD Card into your PC.
+2. Back up your badges at the folder on your SD Card `SD:Nintendo 3DS/ID0/ID1/extdata/00000000/000014d1`.
+3. Download [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)).
 4. Insert your SD Card into your console.
-
 5. Use Nimbus to switch to Pretendo.
-
-6. Open Simple Badge Injector on your console and make a note of the "Nintendo Network ID" value.
-
+6. Open Simple Badge Injector and make a note of the "Nintendo Network ID" value.
 7. Still inside SBI, choose the option to dump your badge data files.
-
-8. Turn off your 3DS and remove the SD card. On your PC, insert your SD card and download and open [Advanced Badge Editor](https://github.com/AntiMach/advanced-badge-editor/releases/latest). Go to File -> Open Data, then choose the folder where BadgeData.dat and BadgeMngFile.dat are.
-
-9. Replace the NNID value with the one you made a note of in SBI earlier.
-
-10. Save the file. It might be a good idea to choose "Save As" and then save them into a different folder so you can separate them into Pretendo and Nintendo versions.
-
-11. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)
-
-This will remove badges from your Nintendo Network account, but all badges will still be intact on Pretendo Network.
+8. Turn off your 3DS and remove the SD card. Insert your SD card into your PC.
+9. Download and open [Advanced Badge Editor](https://github.com/AntiMach/advanced-badge-editor/releases/latest).
+10. Go to `File > Open Data`, then choose the folder where BadgeData.dat and BadgeMngFile.dat are.
+11. Replace the NNID value with the one you made a note of in SBI earlier.
+12. Select `Save As` to save the modified file separately from the backup.
+13. Put your SD card back into your 3DS and go back into SBI
+14. Inject your modified badge data files.
+If you encounter any errors, restore your backed up badge data through SBI. Injecting badges while using Pretendo Network will make them disappear when swapping back to Nintendo Network, and vice versa.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -7,9 +7,9 @@
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder `sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1` and copying them to a safe place
+	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place
 
-[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a.
+[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 1 or 2.
 </div>
 
 <div class="tip">

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -5,6 +5,13 @@
 	SYSTEM TRANSFERS ARE NOT CURRENTLY SUPPORTED BY OUR SERVERS. ATTEMPTING TO PERFORM A SYSTEM TRANSFER MAY PREVENT YOU FROM BEING ABLE TO GO ONLINE IN THE FUTURE. SUPPORT FOR SYSTEM TRANSFERS IS IN DEVELOPMENT.
 </div>
 
+<div class="tip red">
+	<strong>CAUTION:</strong>
+	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder `sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1` and copying them to a safe place
+
+[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a.
+</div>
+
 <div class="tip">
 	ℹ️ This guide assumes that you have a <b>Homebrewed System running the latest version of Luma3DS (13+)</b>, if you don't please follow this <a href="https://3ds.hacks.guide/" target="_blank">guide</a> on how to homebrew your system first.
 </div>

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -7,7 +7,7 @@
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place on your device.
+	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS\[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place.
 
 [ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 0 or 1.
 </div>

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -137,4 +137,4 @@ Follow these steps.
 
 11. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)
 
-This will remove badges from your Nintendo Network accouint, but all badges will be intact on Pretendo Network.
+This will remove badges from your Nintendo Network account, but all badges will be intact on Pretendo Network.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -118,11 +118,12 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 7. Still inside SBI, choose the option to dump your badge data files.
 8. Turn off your 3DS and remove the SD card. Insert your SD card into your PC.
 9. Download and open [Advanced Badge Editor](https://github.com/AntiMach/advanced-badge-editor/releases/latest).
-10. Go to `File > Open Data`, then choose the folder where BadgeData.dat and BadgeMngFile.dat are.
+10. Go to `File > Open Data`, then choose the folder where BadgeData.dat and BadgeMngFile.dat are. (Located at `sd:/3ds/SimpleBadgeInjector/Dumped`)
 11. Replace the NNID value with the one you made a note of in SBI earlier.
 12. Select `Save As` to save the modified file separately from the backup.
-13. Put your SD card back into your 3DS and go back into SBI
-14. Inject your modified badge data files.
+13. Put your modified badge data filed into `sd:/3ds/SimpleBadgeInjector`
+14. Put your SD card back into your 3DS and go back into SBI
+15. Inject your modified badge data files.
 
 All badges on the home menu will be deleted, and you have to re-add them in the order you have had them before.
     

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -7,7 +7,7 @@
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place
+	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place on your device.
 
 [ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 1 or 2.
 </div>

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -125,6 +125,6 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 14. Put your SD card back into your 3DS and go back into SBI
 15. Inject your modified badge data files.
 
-All badges on the home menu will be deleted, and you have to re-add them in the order you have had them before.
+All badges *placed* on the home menu will be deleted, and you have to re-add them in the order you have had them before.
     
 If you encounter any errors, restore your backed up badge data through SBI. Injecting badges while using Pretendo Network will make them disappear when swapping back to Nintendo Network, and vice versa.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -113,18 +113,26 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 ### What do I do if my console says that my badges get erased?
 Follow these steps.
 
-1. Back up your badges at "sdmc:/Nintendo 3DS/<ID0>/<ID1>/extdata/00000000/000014d1" just in case this doesn't work.
+1. Insert your SD Card into your PC
 
-2. Use Nimbus to switch to Pretendo.
+2. Back up your badges at the folder on your SD Card "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place on your device.
 
-3. Install and open [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)) on your 3DS console and make a note of the "Nintendo Network ID" value.
+[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 1 or 2. just in case this doesn't work.
 
-4. Still inside SBI, choose the option to dump your badge data files.
+3. Install [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)) on your 3DS console
 
-5. Turn off your 3DS and remove the SD card. On your PC, insert your SD card and download and open [Advanced Badge Editor](https://github.com/AntiMach/advanced-badge-editor/releases/latest). Go to File -> Open Data, then choose the folder where BadgeData.dat and BadgeMngFile.dat are.
+4. Insert your SD Card into your console.
 
-6. Replace the NNID value with the one you made a note of in SBI earlier.
+5. Use Nimbus to switch to Pretendo.
 
-7. Save the file. It might be a good idea to choose "Save As" and then save them into a different folder so you can separate them into Pretendo and Nintendo versions.
+6. Open Simple Badge Injector on your console and make a note of the "Nintendo Network ID" value.
 
-8. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)
+7. Still inside SBI, choose the option to dump your badge data files.
+
+8. Turn off your 3DS and remove the SD card. On your PC, insert your SD card and download and open [Advanced Badge Editor](https://github.com/AntiMach/advanced-badge-editor/releases/latest). Go to File -> Open Data, then choose the folder where BadgeData.dat and BadgeMngFile.dat are.
+
+9. Replace the NNID value with the one you made a note of in SBI earlier.
+
+10. Save the file. It might be a good idea to choose "Save As" and then save them into a different folder so you can separate them into Pretendo and Nintendo versions.
+
+11. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -9,7 +9,7 @@
 	<strong>CAUTION:</strong>
 	If you try and boot up the 3DS Badge Arcade while on Pretendo server, your badges will be wiped! If you have badges you do not want to be wiped, please do not load Badge Arcade until further notice or make a backup of your badges by going to the folder "sd:Nintendo 3DS[ID0][ID1]\extdata\00000000\000014d1" and copying them to a safe place on your device.
 
-[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 1 or 2.
+[ID0] and [ID1] are place holders, the actual folder names will be 32 characters, such as, ahsy7shdye7hdyeu47jd723jks89i32a. This will not be your actual ID 0 or 1.
 </div>
 
 <div class="tip">

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -137,4 +137,4 @@ Follow these steps.
 
 11. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)
 
-This will remove badges from your Nintendo Network account, but all badges will be intact on Pretendo Network.
+This will remove badges from your Nintendo Network account, but all badges will still be intact on Pretendo Network.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -111,7 +111,7 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 ### Restoring Nintendo Badge Arcade Badges
 1. Insert your SD Card into your PC.
 2. Back up your badges at the folder on your SD Card `SD:Nintendo 3DS/ID0/ID1/extdata/00000000/000014d1`.
-3. Download [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)).
+3. Download [Simple Badge Injector](https://github.com/AntiMach/simple-badge-injector/releases/latest).
 4. Insert your SD Card into your console.
 5. Use Nimbus to switch to Pretendo.
 6. Open Simple Badge Injector and make a note of the "Nintendo Network ID" value.

--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -109,3 +109,22 @@ You may have thought to yourself; _"2nd local account? What's that? I thought th
 <ul id="footnotes">
 	<li id="footnote-1"><sup>[1]</sup> Some games may require a PNID for certain actions, such as eShop purchases. The only known game which requires a PNID for general use is Nintendo Badge Arcade, which is not yet supported</li>
 </ul>
+
+### What do I do if my console says that my badges get erased?
+Follow these steps.
+
+1. Back up your badges at "sdmc:/Nintendo 3DS/<ID0>/<ID1>/extdata/00000000/000014d1" just in case this doesn't work.
+
+2. Use Nimbus to switch to Pretendo.
+
+3. Install and open [Simple Badge Injector]((https://github.com/AntiMach/simple-badge-injector/releases/latest)) on your 3DS console and make a note of the "Nintendo Network ID" value.
+
+4. Still inside SBI, choose the option to dump your badge data files.
+
+5. Turn off your 3DS and remove the SD card. On your PC, insert your SD card and download and open [Advanced Badge Editor](https://github.com/AntiMach/advanced-badge-editor/releases/latest). Go to File -> Open Data, then choose the folder where BadgeData.dat and BadgeMngFile.dat are.
+
+6. Replace the NNID value with the one you made a note of in SBI earlier.
+
+7. Save the file. It might be a good idea to choose "Save As" and then save them into a different folder so you can separate them into Pretendo and Nintendo versions.
+
+8. Put your SD card back into your 3DS and go back into SBI, then inject your modified badge data files. They should now show up with zero issues! (Hopefully, hence the backup)


### PR DESCRIPTION
(this is LiamMGit/LiamM-MTCBs but i had to make this on a alt as i messed up my other fork by changing the master branch, and it didn't let me make a new fork)
A ton of users have been reporting their badges getting wiped while only on Pretendo Network when they try and open Badge Arcade. This does not happen on Nintendo Network. This is just a warning message to let people know and how to backup their badges. 