### PR TITLE
Add password length requirements on registration page

### DIFF
--- a/views/account/register.handlebars
+++ b/views/account/register.handlebars
@@ -25,11 +25,11 @@
 			</div>
 			<div>
 				<label for="password">{{ locale.account.loginForm.password }}</label>
-				<input name="password" id="password" type="password" autocomplete="new-password" required>
+				<input name="password" id="password" type="password" autocomplete="new-password" minlength="6" maxlength="16" required>
 			</div>
 			<div>
 				<label for="password_confirm">{{ locale.account.loginForm.confirmPassword }}</label>
-				<input name="password_confirm" id="password_confirm" type="password" autocomplete="new-password" required>
+				<input name="password_confirm" id="password_confirm" type="password" autocomplete="new-password" minlength="6" maxlength="16" required>
 			</div>
 			<div class="h-captcha" data-sitekey="cf3fd74e-93ca-47e6-9fa0-5fc439de06d4"></div>
 			<input name="redirect" id="redirect" type="hidden" value="{{redirect}}">


### PR DESCRIPTION
Had some trouble creating a Pretendo Account due to password length hints not being sent to the client.

This PR adds the said minimum / maximum requirements of registration to the page.
The number of characters were derived from: https://github.com/PretendoNetwork/account/blob/8c07ae82f90e26424c39b53c9ea73ef7cdaee731/src/services/api/routes/v1/register.js#L164-L178