### PR TITLE
[Feature]: Discourse SSO

### DIFF
--- a/src/middleware/render-data.js
+++ b/src/middleware/render-data.js
@@ -92,6 +92,11 @@ async function renderDataMiddleware(request, response, next) {
 			request.pnid = await database.PNID.findOne({ pid: response.locals.account.pid });
 			request.account = response.locals.account;
 
+			if (request.pnid.deleted) {
+				// TODO - We just need to overhaul our API tbh
+				throw new Error('User not found');
+			}
+
 			return next();
 		} catch (error) {
 			response.cookie('error_message', error.message, { domain: '.pretendo.network' });

--- a/src/schema/pnid.js
+++ b/src/schema/pnid.js
@@ -2,6 +2,7 @@ const { Schema } = require('mongoose');
 
 // Only define what we will be using
 const PNIDSchema = new Schema({
+	deleted: Boolean,
 	pid: {
 		type: Number,
 		unique: true

--- a/src/util.js
+++ b/src/util.js
@@ -247,6 +247,10 @@ async function removeDiscordMemberTesterRole(memberId) {
 	}
 }
 
+function signDiscoursePayload(payload) {
+	return crypto.createHmac('sha256', config.discourse.sso.secret).update(payload).digest('hex');
+}
+
 module.exports = {
 	fullUrl,
 	getLocale,
@@ -265,5 +269,6 @@ module.exports = {
 	assignDiscordMemberSupporterRole,
 	assignDiscordMemberTesterRole,
 	removeDiscordMemberSupporterRole,
-	removeDiscordMemberTesterRole
+	removeDiscordMemberTesterRole,
+	signDiscoursePayload
 };

--- a/views/account/login.handlebars
+++ b/views/account/login.handlebars
@@ -5,9 +5,8 @@
 {{> header}}
 
 <div class="wrapper">
-
 	<div class="account-form-wrapper">
-		<form action="/account/login" method="post" class="account">
+		<form action="{{ loginPath }}" method="post" class="account">
 			<h2>{{ locale.account.loginForm.login }}</h2>
 			<p>{{ locale.account.loginForm.detailsPrompt }}</p>
 			<div>
@@ -23,8 +22,10 @@
 			<input name="redirect" id="redirect" type="hidden" value="{{redirect}}">
 			<div class="buttons">
 				<button type="submit">{{ locale.account.loginForm.login }}</button>
-			<a href="/account/register{{#if redirect}}?redirect={{redirect}}{{/if}}" class="register">{{ locale.account.loginForm.registerPrompt }}</a>
+				<a href="/account/register{{#if redirect}}?redirect={{redirect}}{{/if}}" class="register">{{ locale.account.loginForm.registerPrompt }}</a>
 			</div>
+			<input type="hidden" id="discourse-sso-payload" name="discourse-sso-payload" value="{{ discourse.payload }}" />
+			<input type="hidden" id="discourse-sso-signature" name="discourse-sso-signature" value="{{ discourse.signature }}" />
 		</form>
 	</div>
 </div>

--- a/views/partials/header.handlebars
+++ b/views/partials/header.handlebars
@@ -39,6 +39,9 @@
 		<a href="/progress" class="hide-on-mobile">
 			<button>{{ locale.nav.progress }}</button>
 		</a>
+		<a href="https://forum.pretendo.network" class="hide-on-mobile">
+			<button>Forum</button> <!-- TODO - Translate this -->
+		</a>
 		<a href="/account/upgrade" class="donate">
 			<button>
 				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-heart"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path></svg>
@@ -159,6 +162,15 @@
 						<div>
 							<p class="title">{{ locale.nav.blog }}</p>
 							<p class="caption">{{ locale.nav.dropdown.captions.blog }}</p>
+						</div>
+					</a>
+					<a href="https://forum.pretendo.network">
+						<div class="icon">
+							<svg width="32" height="32" viewBox="0 0 256 256"><path fill="currentColor" d="M216 48H56a16 16 0 0 0-16 16v120a8 8 0 0 1-16 0V88a8 8 0 0 0-16 0v96a24 24 0 0 0 24 24h176a24.1 24.1 0 0 0 24-24V64a16 16 0 0 0-16-16Zm-40 104H96a8 8 0 0 1 0-16h80a8 8 0 0 1 0 16Zm0-32H96a8 8 0 0 1 0-16h80a8 8 0 0 1 0 16Z"/></svg>
+						</div>
+						<div>
+							<p class="title">Forum</p> <!-- TODO - Translate this -->
+							<p class="caption">Chat with others and get support</p> <!-- TODO - Translate this -->
 						</div>
 					</a>
 					<a href="/progress">


### PR DESCRIPTION
As discussed in https://github.com/PretendoNetwork/Pretendo/pull/64, we have an accessibility issue when it comes to information and support. Part of this comes down to our reliance on Discord for a lot of things, which we have been criticized for in the past (and rightfully so).

This PR aims to rectify that. This PR adds in support for [DiscourseConnect](https://meta.discourse.org/t/setup-discourseconnect-official-single-sign-on-for-discourse-sso/13045) SSO. Once this PR is merged, and our Discourse forum hosted, we will be able to open up our forums to users utilizing our PNID account system.

Having a dedicated, web-based, forum will help a lot. We will be able to reach people outside of Discord, including those who don't want to use the platform or are unable to access it/our server (for example banned users, who even if banned from our Discord are still entitled to PNID support).

This allow will allow us, again as discussed in https://github.com/PretendoNetwork/Pretendo/pull/64, to have meaningful technical discussions with contributors outside of our developer channels on Discord (which are currently a supporter perk, one which I am hesitant to make public out of fear of taking something away from supporters).

I am still working out some kinks with Discourse, but their support team has been top notch so that shouldn't take long.

PR does include some hacks, but that's because the website is written poorly in general. The rewrite will clean it up a lot.