### PR TITLE
Fix upgrade.js script tag

### DIFF
--- a/views/account/upgrade.handlebars
+++ b/views/account/upgrade.handlebars
@@ -112,5 +112,5 @@
 			.replace('${perc}', '{{donationCache.completed_real}}');
 	</script>
 
-	<script src="/assets/js/upgrade.js" />
+	<script src="/assets/js/upgrade.js"></script>
 {{/section}}


### PR DESCRIPTION
On the upgrade page, the `upgrade.js` script uses a self-closing `<script>` tag. This is not valid HTML.

As far as I can tell, in production, the upgrade script is only loaded because Cloudflare adds an analytics script, which adds an extra `</script>` tag to the end of the HTML. This leads to Chrome parsing the page like this, which doesn't seem right:
![image](https://github.com/PretendoNetwork/website/assets/73856503/76cd9842-ba05-4bfc-8742-ec61b94a432e)