### PR TITLE
Fix CJK characters in user widget

### DIFF
--- a/public/assets/css/partials/header.css
+++ b/public/assets/css/partials/header.css
@@ -371,6 +371,7 @@ header .user-widget .button {
 	width: 100%;
 	padding: 8px 60px;
 	cursor: pointer;
+	word-break: keep-all;
 }
 header .user-widget .button.logout {
 	background: var(--bg-shade-3);


### PR DESCRIPTION
Adds a CSS rule to prevent CJK chars from pointlessly breaking.
![image](https://github.com/PretendoNetwork/website/assets/35656715/1fae049c-1575-474d-9817-f1d0c4ff442c)
Fixes issue #279.  
