### PR TITLE
Updated the CEMU Guide to indicate the requirement of Dumping from your Wii U

### DIFF
--- a/docs/en_US/install/cemu.md
+++ b/docs/en_US/install/cemu.md
@@ -2,6 +2,10 @@
 
 # Cemu
 
+<div class='tip'>
+	In Order to use Pretendo on Cemu, you need to have Pretendo already installed on your Wii U. For Wii U please follow the <a href='/docs/install/wiiu'>Wii U Guide</a>
+</div>
+
 ## Download
 <div class="tip red">
 	<strong>Note:</strong>
@@ -10,6 +14,7 @@
 
 Cemu 2.0 has official built-in support for Pretendo as of October 10, 2022. Head to the Cemu GitHub [releases](https://github.com/cemu-project/Cemu/releases) page and download the latest Cemu experimental release (tagged as `Pre-release`). Only `Cemu 2.0-5 (Experimental)` and above is supported at the moment. Additionally you may build Cemu from source using the provided [build instructions](https://github.com/cemu-project/Cemu/blob/main/BUILD.md)
 
+## Dumping your pretendo account
 Ensure you have followed [Cemu's guide](https://cemu.cfw.guide/online-play.html) to set up the emulator for online play. When dumping your user account files, ensure you select your PNID.
 
 ## Connecting to Pretendo


### PR DESCRIPTION
_This PR was requested by the CEMU mod team._

This PR updated the CEMU Guide to Indicate that it is required to have a Pretendo Account already setup on the Wii U (since it was able to download the account data from the website) .