### PR TITLE
Fixed blog post header hiding part of section when navigating using table of contents

### DIFF
--- a/public/assets/css/blogpost.css
+++ b/public/assets/css/blogpost.css
@@ -196,6 +196,17 @@ header {
 	margin-bottom: 30px;
 }
 
+@media screen and (min-width: 901px) {
+	.blog-card h1,
+	.blog-card h2,
+	.blog-card h3,
+	.blog-card h4,
+	.blog-card h5,
+	.blog-card h6 {
+		scroll-margin-top: 110px;
+	}
+}
+
 @media screen and (max-width: 800px) {
 	.blog-card {
 		padding: 40px;


### PR DESCRIPTION
Resolves #263

### Changes:

public/assets/css/blogpost.css:199-208
```css
@media screen and (min-width: 901px) {
	.blog-card h1,
	.blog-card h2,
	.blog-card h3,
	.blog-card h4,
	.blog-card h5,
	.blog-card h6 {
		scroll-margin-top: 110px;
	}
}
```
To prevent the header from eclipsing part of selected section when navigating using the table of contents, I have added `scroll-margin-top: 110px;` to every heading within `.blog-card` to have the blog post page scroll appropriately. As different posts use different heading tags, I opted to include every heading tag in case one otherwise not included would be used in the future.

Previously, the heading and part of the text would be hidden behind the header when navigating using table of contents, forcing the user to scroll up again. This was only a problem when the header would be following the viewport (at viewport width > 900px), therefore I used `@media screen and (min-width: 901px)` to keep scrolling with table of contents as usual when the header wouldn't be in the way.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.