### PR TITLE
Add "immediately" to unsubPrompt to avoid vagueness

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -225,7 +225,7 @@
 		"month": "Monat",
 		"tierSelectPrompt": "Wähle eine Stufe",
 		"unsub": "Deabonnieren",
-		"unsubPrompt": "Bist du dir sicher, dass du <span>tiername</span> deabonnieren möchtest? Du wirst den Zugang zu den Vorteilen verlieren, die mit dieser Stufe verbunden sind.",
+		"unsubPrompt": "Bist du dir wirklich sicher, dass du dich von <span>Tiername</span> ablemden möchtest? Du wirst  <span>sofort</span> den Zugriff auf die Vorteile dieser Stufe verlieren.",
 		"unsubConfirm": "Deabonnieren",
 		"changeTier": "Stufe ändern",
 		"changeTierPrompt": "Bist du dir sicher, dass du <span class=\"oldtier\">oldtiername</span> deabonnieren und <span class=\"newtier\">newtiername</span> abonnieren möchtest?",

--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -225,7 +225,7 @@
 		"month": "Monat",
 		"tierSelectPrompt": "Wähle eine Stufe",
 		"unsub": "Deabonnieren",
-		"unsubPrompt": "Bist du dir wirklich sicher, dass du dich von <span>Tiername</span> ablemden möchtest? Du wirst  <span>sofort</span> den Zugriff auf die Vorteile dieser Stufe verlieren.",
+		"unsubPrompt": "Bist du dir wirklich sicher, dass du dich von <span>tiername</span> ablemden möchtest? Du wirst  <span>sofort</span> den Zugriff auf die Vorteile dieser Stufe verlieren.",
 		"unsubConfirm": "Deabonnieren",
 		"changeTier": "Stufe ändern",
 		"changeTierPrompt": "Bist du dir sicher, dass du <span class=\"oldtier\">oldtiername</span> deabonnieren und <span class=\"newtier\">newtiername</span> abonnieren möchtest?",

--- a/locales/en@uwu.json
+++ b/locales/en@uwu.json
@@ -222,7 +222,7 @@
 		"unsub": "stop being super kitteh :(",
 		"description": "reachin goal givez kittehz muns for devin, gettin better new stuffz fastr!!",
 		"back": "bak",
-		"unsubPrompt": "are u sur u wanna stop bein <span>tiername</span>?! u will lose all kitteh perkz instantly!!",
+		"unsubPrompt": "are u sur u wanna stop bein <span>tiername</span>?! u will lose all kitteh perkz immediately!!",
 		"changeTier": "change super kitteh level",
 		"changeTierConfirm": "yezyez, change!!"
 	},

--- a/locales/en_GB.json
+++ b/locales/en_GB.json
@@ -228,7 +228,7 @@
 		"description": "Reaching the monthly goal will make Pretendo a full time job, providing better quality updates at a faster rate.",
 		"month": "month",
 		"tierSelectPrompt": "Select a tier",
-		"unsubPrompt": "Are you sure you want to unsubscribe from <span>tiername</span>? You will lose access to the perks associated with that tier.",
+		"unsubPrompt": "Are you sure you want to unsubscribe from <span>tiername</span>? You will <span>immediately</span> lose access to the perks associated with that tier.",
 		"changeTier": "Change tier",
 		"changeTierPrompt": "Are you sure you want to unsubscribe from <span class=\"oldtier\">oldtiername</span> and subscribe to <span class=\"newtier\">newtiername</span>?"
 	},

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -338,7 +338,7 @@
 		"month": "month",
 		"tierSelectPrompt": "Select a tier",
 		"unsub": "Unsubscribe",
-		"unsubPrompt": "Are you sure you want to unsubscribe from <span>tiername</span>? You will lose access to the perks associated with that tier.",
+		"unsubPrompt": "Are you sure you want to unsubscribe from <span>tiername</span>? You will <span>immediately</span> lose access to the perks associated with that tier.",
 		"unsubConfirm": "Unsubscribe",
 		"changeTier": "Change tier",
 		"changeTierPrompt": "Are you sure you want to unsubscribe from <span class='oldtier'>oldtiername</span> and subscribe to <span class='newtier'>newtiername</span>?",

--- a/locales/es_ES.json
+++ b/locales/es_ES.json
@@ -262,7 +262,7 @@
 		"month": "mes",
 		"tierSelectPrompt": "Selecciona un rango",
 		"unsub": "Cancelar suscripción",
-		"unsubPrompt": "¿Está seguro de que desea darse de baja de <span>tiername</span>? Perderá el acceso a las ventajas asociadas con ese nivel.",
+		"unsubPrompt": "¿Está seguro de que desea darse de baja de <span>tiername</span>? Perderá <span>inmediatamente</span> el acceso a las ventajas asociadas con ese nivel.",
 		"unsubConfirm": "Cancelar suscripción",
 		"changeTier": "Cambiar rango",
 		"changeTierPrompt": "¿Está seguro de que desea darse de baja de <span class=\"oldtier\">oldtiername</span> y suscribirse a <span class=\"newtier\">newtiername</span>?",

--- a/locales/fr_FR.json
+++ b/locales/fr_FR.json
@@ -264,7 +264,7 @@
 		"month": "mois",
 		"tierSelectPrompt": "Sélectionnez un niveau",
 		"unsub": "Se désabonner",
-		"unsubPrompt": "Êtes-vous sûr de vouloir vous désabonner du <span>tiername</span> ? Vous perdrez toutes les récompenses associées à ce niveau.",
+		"unsubPrompt": "Êtes-vous sûr de vouloir vous désabonner du <span>tiername</span> ? Vous perdrez toutes les récompenses associées à ce niveau <span>immédiatement</span>.",
 		"unsubConfirm": "Se désabonner",
 		"changeTier": "Changer de niveau",
 		"changeTierConfirm": "Changer de niveau",

--- a/locales/it_IT.json
+++ b/locales/it_IT.json
@@ -258,7 +258,7 @@
 		}
 	},
 	"upgrade": {
-		"unsubPrompt": "Sei sicuro di voler annullare l'iscrizione a <span>tiername</span>? Perderai tutte le ricompense associate a quel livello.",
+		"unsubPrompt": "Sei sicuro di voler annullare l'iscrizione a <span>tiername</span>? Perderai tutte le ricompense <span>immediatamente</span> associate a quel livello.",
 		"description": "Raggiungere il goal mensile renderà Pretendo un lavoro a tempo pieno, permettendo di fornire aggiornamenti di maggiore qualità in meno tempo.",
 		"month": "mese",
 		"tierSelectPrompt": "Seleziona un livello",


### PR DESCRIPTION
I talked to Jon about this earlier in Discord on a thread about a cancellation ending perks immediately, where the prompt was too vague.

A PR just to add "immediately"; still WIP with mods on Discord.