### PR TITLE
Reduce Mii editor HTTP requests from 4 to 1 on every change

### DIFF
--- a/public/assets/js/miieditor.js
+++ b/public/assets/js/miieditor.js
@@ -5,7 +5,7 @@
  *
  * browserify is needed for the use of require() in the browser
  */
-const Mii = require('@pretendonetwork/mii-js').default;
+const Mii = require('mii-js');
 const newMiiData = 'AwAAQOlVognnx0GC2qjhdwOzuI0n2QAAAGBzAHQAZQB2AGUAAAAAAAAAAAAAAEBAAAAhAQJoRBgmNEYUgRIXaA0AACkAUkhQAAAAAAAAAAAAAAAAAAAAAAAAAAAAANeC';
 
 // Prevent the user from reloading or leaving the page

--- a/public/assets/js/miieditor.js
+++ b/public/assets/js/miieditor.js
@@ -69,8 +69,8 @@ function initializeMiiData(encodedUserMiiData) {
 		bgColor: '13173300',
 		expression: 'sorrow',
 	});
-	document.querySelector('.mii-comparison img.old-mii').src = miiStudioNeutralUrl;
-	document.querySelector('.mii-comparison.confirmed img.old-mii').src = miiStudioSorrowUrl;
+	document.querySelector('.mii-comparison img.old-mii').setAttribute('data-src', miiStudioNeutralUrl);
+	document.querySelector('.mii-comparison.confirmed img.old-mii').setAttribute('data-src', miiStudioSorrowUrl);
 	console.log('initialization complete');
 	console.groupEnd();
 	return true;
@@ -184,8 +184,8 @@ function renderMii(heightOverride, buildOverride) {
 		});
 
 		// sets the new mii in the save tab to the new mii
-		document.querySelector('.mii-comparison img.new-mii').src = faceMiiStudioUrl;
-		document.querySelector('.mii-comparison.confirmed img.new-mii').src = faceMiiStudioSmileUrl;
+		document.querySelector('.mii-comparison img.new-mii').setAttribute('data-src', faceMiiStudioUrl);
+		document.querySelector('.mii-comparison.confirmed img.new-mii').setAttribute('data-src', faceMiiStudioSmileUrl);
 	}
 }
 
@@ -371,6 +371,18 @@ function openTab(e, tabType) {
 		.replace('SubButton', '')
 		.replace('Button', buttonReplacement);
 	document.querySelector(`#${selectedID}`).classList.add('active');
+
+	// if you selected the save tab...
+	if (selectedID === 'saveTab') {
+		// set data-src on images that have it to src
+		// effectively loading them right now (lazy load)
+		document
+			.querySelectorAll('#saveTab img[data-src]')
+			.forEach(e => {
+				if (e.getAttribute('data-src') !== e.src)
+					e.setAttribute('src', e.getAttribute('data-src'));
+			});
+	}
 
 	if (tabType === 'tab') {
 		// Click the first subtab button, if there is one


### PR DESCRIPTION
Currently on the Pretendo Mii editor, four requests are made every single time a change is made to the Mii. Here's what those are and how this PR addresses them:
* Two requests for icons meant for the save screen, representing the old Mii with a sorrow expression and new Mii with a happy expression.
  - Needlessly updated on every single change when they only show on the save screen.

Those icons are now deferred and not requested on every change.
* Two more requests for the actual Mii head shown and a bald version.

The bald head is meant to maintain the neck when a Mii's hair goes behind it. Here's what would happen if you overlaid the head of such a Mii without accounting for this:

<img src="https://github.com/user-attachments/assets/d67e961f-0a0e-4965-a4dc-f7fcd823d8b7" height="400">


But more requests to Nintendo is never a good thing, and they have a solution for this that had not been in the mii-js repo for the longest time: the `splitMode` param puts the front part and back part of the head in the same image. That is used by this commit and the result looks like it should.
  
<img src="https://github.com/user-attachments/assets/8a3cc6e7-cfc6-4c5d-8017-418d3eba9056" height="400">


(I held off on submitting the PR to the website back in September because I thought it needed a corresponding change to add the splitMode field in mii-js. Nobody responded to my PR. Turns out it this still works without that. OOOOOOOPS!)