### PR TITLE
Add Bluesky account to the footer

### DIFF
--- a/views/partials/footer.handlebars
+++ b/views/partials/footer.handlebars
@@ -35,6 +35,7 @@
 		<a href="https://mastodon.pretendo.network/@pretendo" target="_blank" rel="me">Mastodon</a>
 		<a href="https://discord.gg/pretendo" target="_blank">Discord</a>
 		<a href="https://github.com/PretendoNetwork" target="_blank">GitHub</a>
+		<a href="https://bsky.app/profile/pretendo.network" target="_blank">Bluesky</a>
 	</div>
 	<div>
 		<h1>{{ locale.footer.usefulLinks }}</h1>


### PR DESCRIPTION
Resolves #362 

### Changes:

Adds the Pretendo Network Bluesky account to the footer. From what I saw on Bluesky (I don't use social media much), the official account is `@pretendo.network`, but do tell me if it's not the real one.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.