### PR TITLE
Delete Text for Removing NNID on Wii U Install Guide

### DIFF
--- a/docs/en_US/install/3ds.md
+++ b/docs/en_US/install/3ds.md
@@ -104,7 +104,7 @@ It is recommended to register the PNID on your device at this time, as registeri
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	A Pretendo Network ID may not use the same username as the account already linked to your 3DS! Ensure that you have a choose a different name for your PNID than the name on your NNID.
+	A Pretendo Network ID may not use the same username as the account already linked to your 3DS! Ensure that you have chosen a different name for your PNID than the name on your NNID.
 </div>
 
 ## Other information

--- a/docs/en_US/install/wiiu.md
+++ b/docs/en_US/install/wiiu.md
@@ -151,7 +151,7 @@ After installing Pretendo, you must register a Pretendo Network ID (PNID). There
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	A Pretendo Network ID may not use the same username as an account already linked to your Wii U! Ensure that you have a choose a different name for your PNID than the name on your NNID.
+	A Pretendo Network ID may not use the same username as an account already linked to your Wii U! Ensure that you have chosen a different name for your PNID than the name on your NNID.
 </div>
 
 ### Website

--- a/docs/en_US/install/wiiu.md
+++ b/docs/en_US/install/wiiu.md
@@ -151,7 +151,7 @@ After installing Pretendo, you must register a Pretendo Network ID (PNID). There
 
 <div class="tip red">
 	<strong>CAUTION:</strong>
-	A Pretendo Network ID may not use the same username as an account already linked to your Wii U! If you have any existing Nintendo Network IDs on your Wii U which share the username you wish to use, those accounts MUST be removed from your console first.
+	A Pretendo Network ID may not use the same username as an account already linked to your Wii U! Ensure that you have a choose a different name for your PNID than the name on your NNID.
 </div>
 
 ### Website


### PR DESCRIPTION
Changes:

1. Delete Text for Removing NNID on Wii U Install Guide

Reasoning:
The act of removing an NNID is unnecessary at best, harmful at worst.

Having that text there contradicts the "Caution" at top of the page, and also might lead people to believe that it is okay to do that.

This PR removes that text, and copies the one from the 3DS page (along with a grammar edit).