### PR TITLE
Mississippi/birthdays

### DIFF
--- a/src/routes/account.js
+++ b/src/routes/account.js
@@ -112,7 +112,13 @@ router.get('/register', async (request, response) => {
 });
 
 router.post('/register', async (request, response) => {
-	const { email, username, mii_name, password, password_confirm, 'h-captcha-response': hCaptchaResponse } = request.body;
+	const { email, username, mii_name, birthday, password, password_confirm, 'h-captcha-response': hCaptchaResponse } = request.body;
+
+	// * IP must be forwarded to the account server so we can check for age related issues based on region.
+	// * This is NEVER recorded in our records, ever. See https://github.com/PretendoNetwork/account/pull/194
+	// * for more details. Once the IP is used to query for location, both the IP and location are disregarded
+	// * and no data is stored for blocked users
+	const ip = request.ip; // TODO - Enable `CF-IPCountry` in Cloudflare and only use this as a fallback
 
 	response.cookie('email', email, { domain: '.pretendo.network' });
 	response.cookie('username', username, { domain: '.pretendo.network' });
@@ -120,9 +126,11 @@ router.post('/register', async (request, response) => {
 
 	try {
 		const tokens = await util.register({
+			ip,
 			email,
 			username,
 			mii_name,
+			birthday,
 			password,
 			password_confirm,
 			hCaptchaResponse

--- a/src/server.js
+++ b/src/server.js
@@ -19,6 +19,8 @@ const { http: { port } } = config;
 const app = express();
 // const stripe = new Stripe(config.stripe.secret_key);
 
+app.set('trust proxy', true); // TODO - Make this configurable
+
 logger.info('Setting up Middleware');
 app.use(morgan('dev'));
 // app.use(express.json());

--- a/views/account/register.handlebars
+++ b/views/account/register.handlebars
@@ -24,6 +24,11 @@
 				<input name="mii_name" id="mii_name" value="{{ mii_name }}" maxlength=10 required>
 			</div>
 			<div>
+				<label for="birthday">Birthday</label> {{! TODO - Add this to weblate, hard-coding for now to just push it out }}
+				<input type="date" id="birthday" name="birthday">
+			</div>
+			<br>
+			<div>
 				<label for="password">{{ locale.account.loginForm.password }}</label>
 				<input name="password" id="password" type="password" autocomplete="new-password" minlength="6" maxlength="16" required>
 			</div>


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds 2 new fields to registration:

- Birthday
- Client IP

The Client IP is never stored anywhere, it's just forwarded to the account user since the IP of the registration request will be the websites IP address

This needs to be forwarded because Mississippi added extremely strict new laws recently about parental verification for minors, so now we need to ensure we are not letting minors in Mississippi register. See https://github.com/PretendoNetwork/account/pull/194 for more details

Changes untested, but they should work

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.