### PR TITLE
feat(docs): Update SDMC folder instruction in Azahar guide

### DIFF
--- a/docs/en_US/install/azahar.md
+++ b/docs/en_US/install/azahar.md
@@ -92,7 +92,7 @@ Select the `System` menu and click `Enable required LLE modules for online featu
 
 Download the [latest Nimbus release](https://github.com/PretendoNetwork/Nimbus/releases/latest). Be sure to select a zip file labeled either `cia` or `combined`. Once downloaded, extract this zip file.
 
-Open your emulator's SDMC folder. By default, this will be located in the main Azahar folder. To get there, click `File` and `Open Azahar Folder`. A file explorer window will open. Enter the `sdmc` folder and paste the `3ds` folder from the zip file into there. If everything goes correct, inside the `sdmc` folder you should have two folders named `3ds` and `Nintendo 3DS` (with the `Nintendo 3DS` folder already being present).
+Click `File` and hover over `Open Azahar Folder`, then click on `SDMC Folder`. A file explorer window will open. Paste the `3ds` folder from the zip file into here. If everything goes correct, you should have two separate folders next to each other named `3ds` and `Nintendo 3DS` (with the `Nintendo 3DS` folder already being present).
 
 Close Azahar and re-open it. Click `File` and `Install CIA`. Navigate into the `cias` folder from the zip file and select `nimbus.cia`, then click OK. This will install Nimbus to your emulator.
 


### PR DESCRIPTION
This pr is made in preparation of the release of Azahar 2126.0, which includes an easier way to access the SDMC folder. That feature was added because some people who used the Pretendo Azahar guide were confused by their SDMC folder not being in the default location. When the Azahar guide was first written, I wrote it with the default SDMC location in mind because we thought that the user wouldn't change their SDMC directory unless they know what they're doing, and would therefore know to plug in the location they configured when they get to this part of the guide. Unfortunately, we later found that there are some user configurations where the SDMC directory is not default, but the user themselves did not knowingly change it. The discovered use case was EmuDeck, a simple emulator installer primarily designed for Steam Deck and other PC gaming handhelds. EmuDeck automatically switches the SDMC directory to an external drive (such as the Steam Deck's SD card) when the user configures EmuDeck to load games from an external drive instead of the primary one. This resulted in a scenario where a user had their SDMC directory pointed to their Steam Deck's SD card, and they could not proceed with the installation process because they couldn't find their SDMC folder in its default location. With this new feature being added in Azahar 2126.0, this will alleviate the edge case by giving a button to open a file explorer window in wherever the SDMC folder is, without relying on the user knowing where exactly it is on their system.

**Please do not make this edit go live until Azahar 2126.0 is released.** This is currently estimated to happen around late July or early August.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.